### PR TITLE
Outline results: scpca-nf overview

### DIFF
--- a/content/03.results.md
+++ b/content/03.results.md
@@ -29,7 +29,7 @@
   - The workflow uses `salmon alevin` and `alevin-fry` to quantify gene expression data and outputs both raw and normalized counts stored as `SingleCellExperiment` and `AnnData` objects.
   - In building the workflow we sought to look for a tool that was fast and memory efficient with comparable results to other popular tools, like `Cell Ranger`.
   - Reads are aligned using the selective alignment option of `salmon alevin` to an index with transcripts corresponding to spliced cDNA and intronic regions, denoted by `alevin-fry` as a `splici` index.
-  - We compared quantification of 3 single-cell and 3 single-nuclei samples with `alevin-fry` and `Cell Ranger` and observed a decrease in both run time and memory usage in `alevin-fry` compared to `Cell Ranger` (FigS1A).
+  - We compared quantification of single-cell and single-nuclei samples with `alevin-fry` and `Cell Ranger` and observed a decrease in both run time and memory usage in `alevin-fry` compared to `Cell Ranger` (FigS1A).
   - When comparing the total UMIs per cell, total genes detected per cell, and mean gene expression, there was no observable difference between `alevin-fry` and `Cell Ranger` (FigS1B-D).
   - By utilizing `alevin-fry` in the `scpca-nf` workflow we can process multiple samples at a fraction of the time and cost.
 
@@ -38,6 +38,7 @@
   - The output from  `alevin-fry` includes a gene by cell count matrix for all barcodes identified, even those that may not contain true cells. This matrix is stored in a `SingleCellExperiment` and output from the workflow as an `_unfiltered.rds` file.
   - The unfiltered gene by cell counts matrices are then filtered using `DropletUtils::emptyDropsCellRanger()` to remove any barcodes that are not likely to contain cells. All cells that pass this filtering are saved to a filtered `SingleCellExperiment` object and `_filtered.rds` file.
   - This filtered object is used as input to the post-processing part of the workflow. This includes removal of low-quality cells using `miQC`, normalization, and dimensionality reduction. The final step of the post-processing performed in `scpca-nf` is classification of cell types using automated methods, `SingleR` and `CellAssign`. The results from this analysis are stored in a processed object saved to a `processed.rds`.
+  - By providing all three files, unfiltered, filtered, and processed this allows users to perform their own filtering and normalization or to skip those steps and use the already processed objects.
   - Finally, all `SingleCellExperiment` objects saved as `.rds` files are converted to `AnnData` objects and saved as `.hdf5` files to allow for downstream processing in either R or Python.
   - On the Portal, users can choose to download data as either `SingleCellExperiment` or `AnnData` objects and all downloads will contain all three objects output from `scpca-nf`, the unfiltered, filtered, and processed objects (do we include the download illustrations in the figure to display this?)
 
@@ -52,9 +53,7 @@
 
 4. Benefits of scpca-nf/ Nextflow allows for reproducibility and portability (Does this fit here or should it be earlier before describing the workflow?)
   - Using Nextflow as the backbone for the `scpca-nf` workflow ensures reproducibility and portability for users on other systems.
-  - Nextflow handles all dependencies automatically and set up generally requires only organizing input files and configuring Nextflow for your environment.
+  - The scpca-nf workflow can be run in almost any environment including slurm, torque, AWS batch, etc (https://www.nextflow.io/docs/latest/executor.html). This allows users to run this workflow in the environment that they are comfortable in with minimal set-up of dependencies.
+  - Nextflow handles all dependencies automatically and set up generally requires only organizing input files and configuring Nextflow to run in your environment.
   - Each process in the workflow is run in a docker container, so users only need to install Nextflow and docker to be able to use this workflow.
   - Nextflow also handles parallelizing processing based on your environment and will configure processing so that run time is minimal.
-  - In addition to the data that we processed through `scpca-nf`, there are a handful of projects on the Portal that we did not process, as external users were able to implement and run `scpca-nf` on their own raw data prior to submission.
-  - Because of the portability of `scpca-nf`, members of the pediatric research community with single-cell and single-nuclei data are able to run the workflow in the environment of their choice and process samples in the same uniform way that samples on the Portal have been processed.
-  - This allows us to easily grow the Portal and accept contributions from the community and allows users to process their own data in a quick-efficient manner for easy comparison to samples on the Portal.


### PR DESCRIPTION
Closes #4 
Stacked on #17 

This adds the section to the results that covers supplemental figure 1 (benchmarking alevin-fry) and figure 2 (scpca-nf overview and qc report). 

- What do we think of the order of the sections here? I first talked about quantification and using alevin-fry, then the rest of the workflow and the qc report. The last section talks about the benefits of Nextflow and how creating a portable workflow like this has allowed us to solicit external contributions. Do we think this section should go earlier? Or in a different place entirely? 
- What do we think about the level of detail of the actual workflow. I don't think we need to be as detailed as what's in [Processing information docs](https://scpca.readthedocs.io/en/stable/processing_information.html), but I think we want to mention the general steps and the output from each step. If there's anything critical missing, please let me know. 