### PR TITLE
Outline sections needed in methods

### DIFF
--- a/content/04.methods.md
+++ b/content/04.methods.md
@@ -48,10 +48,4 @@
 ### Converting SingleCellExperiment objects to AnnData objects
   - use of zellkonverter
 
-
-There are probably more sections here we might want to include about the Portal itself? Anything related to building it?
-Do we need to mention anything about the terms of use with the data here?
-
 ### Code and data availability
-
-### Limitations section (do we need this?)


### PR DESCRIPTION
Closes #9 

Here I'm adding a section for materials and methods. The main thing I wanted to accomplish here was identifying what sections we should have and what exactly we should be sure to include in the methods. To me, most of the methods are around processing the data that's on the portal, so we should be able to take most of that from the [processing section of the docs](https://scpca.readthedocs.io/en/stable/processing_information.html). 

Are there sections that should be included and are missing? I wasn't sure if we also wanted to include information about the actual set up and design of the Portal? I feel like the answer to that is yes.

Also do we need a section explaining the terms of use of the data on the Portal? Mainly that section would link people to our terms of use. 