### PR TITLE
Add GHA to deploy PR previews

### DIFF
--- a/.github/workflows/deploy-pr.yaml
+++ b/.github/workflows/deploy-pr.yaml
@@ -1,0 +1,19 @@
+# .github/workflows/preview.yml
+name: Deploy PR previews
+concurrency: preview-${{ github.ref }}
+on:
+  pull_request:
+    branch: main
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: npm i && npm run build
+        if: github.event.action != 'closed'
+      - uses: rossjrw/pr-preview-action@v1
+        with: # https://github.com/marketplace/actions/deploy-pr-preview#configuration
+          source-dir: .
+          preview-branch: output
+          umbrella-dir: pr-preview
+          action: auto

--- a/.github/workflows/manubot.yaml
+++ b/.github/workflows/manubot.yaml
@@ -99,21 +99,3 @@ jobs:
           CI_BUILD_WEB_URL: https://github.com/${{ github.repository }}/commit/${{ github.sha }}/checks
           CI_JOB_WEB_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: bash ci/deploy.sh
-  deploy-preview:
-    runs-on: ubuntu-20.04
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Install and Build
-        if: github.event.action != 'closed' # You might want to skip the build if the PR has been closed
-        run: |
-          npm install
-          npm run build
-      - name: Deploy preview
-        uses: rossjrw/pr-preview-action@v1
-        with:
-          source-dir: .
-          preview-branch: output
-          action: auto # https://github.com/marketplace/actions/deploy-pr-preview#configuration


### PR DESCRIPTION
This PR is updating the GHA to include deployment of PR previews, via https://github.com/marketplace/actions/deploy-pr-preview. 

Will it work? We're not sure! But, it in theory won't run when no files are changed, so it may not run in this PR. Let's find out.