### PR TITLE
Add step to post artifact comment to GHA

### DIFF
--- a/.github/workflows/manubot.yaml
+++ b/.github/workflows/manubot.yaml
@@ -107,5 +107,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            **Click the link below to download the manuscript build as a ZIP file:**
+            **Click the link below to download the manuscript build as a ZIP file.**
+            This build is associated with commit ${{ env.TRIGGERING_SHA_7 }}.
+
             [Manuscript build](${{ steps.artifact-upload-step.outputs.artifact-url }})


### PR DESCRIPTION
Closes #25 

This PR updates the GHA to also post a PR comment with the manuscript build. This was happily made more straightforward by the recent release of `upload-artifact@v4`, which provides [an artifact URL output](https://github.com/actions/upload-artifact?tab=readme-ov-file#outputs)! I bumped that version, added the necessary permissions to write to PRs, and used `peter-evans/create-or-update-comment@v4` to post the comment.

I also cleared out some things that didn't need to be there, like the `master` branch and cron comments.

If all goes well, we should see a comment in this PR!