### PR TITLE
Add Figure 1 legend

### DIFF
--- a/content/100.figure-table-legends.md
+++ b/content/100.figure-table-legends.md
@@ -1,6 +1,6 @@
 ## Figure Titles and Legends
 
-[**Figure 1. Overview of ScPCA Portal contents.**](https://github.com/AlexsLemonade/scpca-paper-figures/blob/main/figures/compiled_figures/pngs/figure_1.png)
+![**Figure 1. Overview of ScPCA Portal contents.**](https://github.com/AlexsLemonade/scpca-paper-figures/blob/main/figures/compiled_figures/pngs/figure_1.png){#fig:fig1 width="7in"}
 A. Barplots showing sample counts across four main cancer groupings in the ScPCA Portal, with each bar displaying the number of samples for each cancer type.
 Each bar is shaded based on the number of samples with each disease timing, and total sample counts for each cancer type are shown to the right of each bar.
 B. Barplot showing sample counts across types of modalities present in the ScPCA Portal.


### PR DESCRIPTION
Closes #10 
This PR adds the legend for Figure 1. I placed (edit) it** in a file for figure/table legends that is numbered `100` to appear as the _last_ file in the build.

Here is figure 1 for reference: https://github.com/AlexsLemonade/scpca-paper-figures/blob/2ebc50dd2c9071ceb2487d97b9daaf52f7c11826/figures/compiled_figures/pngs/figure_1.png 

Questions for reviewers:
- Is `100` the right order here, or should it be moved up before references? 
- More/less detail anywhere?
- I struggled a little bit to clearly explain the colors in panel B and how modalities relate to the "all samples" bar. How did I do?