### PR TITLE
Outline: Results - project downloads and merged objects

### DIFF
--- a/content/03.results.md
+++ b/content/03.results.md
@@ -99,15 +99,16 @@
   - By default, when downloading a project, the download will include a folder for each sample that is included in the project.
   - That folder will contain all individual `SingleCellExperiment` objects as `.rds` files or `AnnData` objects as `.hdf5` files, depending on the file format chosen by the user (Fig. 3A).
   - Each of these objects contains the gene expression data and metadata for a single library.
-  - Alternatively, the user can choose to download all samples as a single, merged `SingleCellExperiment` or `AnnData` object (Fig. 3B).
+  - If a given project has associated bulk RNA-seq, then a sample by gene counts matrix, `bulk_quant.tsv`, including the quantified gene expression data for all samples in a project with associated bulk RNA-seq will be included.
+2. Merged objects
+  - Providing all data from all libraries withing a single file makes it easier for users to perform joint analysis on multiple samples at the same time. 
+  Specifically, these objects can be useful for comparing gene-level metrics across multiple samples, such as differential expression analysis and gene set enrichment analysis.
+  - Therefore, we make a single, merged `SingleCellExperiment` or `AnnData` object (Fig. 3B) available for each project (without batch-correction or integration).
   - This file contains one object with all raw and normalized gene expression data and metadata for all single-cell and single-nuclei RNA-seq libraries within a given ScPCA project
-  - Providing all data from all libraries withing a single file makes it easier for users to perform joint analysis on multiple samples at the same time. Specifically, these objects can be useful for comparing gene-level metrics across multiple samples, such as differential expression analysis and gene set enrichment analysis.
-  - Note that the data in the merged object has not been batch-corrected or integrated.
   - If downloading a project that contains at least one library with CITE-seq, the quantified CITE-seq expression data will also be merged. In SCEs this is provided as an `altExp` within the main object, but for `AnnData` objects, the quantified CITE-seq data is provided as a separate file.
-  - Regardless of downloading as single files or merged file, if a given project has associated bulk RNA-seq, then a sample by gene counts matrix, `bulk_quant.tsv`, including the quantified gene expression data for all samples in a project with associated bulk RNA-seq will be included.
 
 2. The merged object workflow (Fig. 3C and 3D)
-  - To create the merged objects, we created an additional stand-alone workflow for merging the output from `scpca-nf`, `merge.nf`. This workflow is open-source and available in the `scpca-nf` repository (Fig. 3C).
+  - To create the merged objects, we created an additional stand-alone workflow for merging the output from `scpca-nf`, `merge.nf` (Fig. 3C).
   - Following processing of each `SingleCellExperiment` object with `scpca-nf`, all processed objects from all libraries and samples within a project are input to the merge workflow, which combines all input data into a single merged object.
   - The merged object contains raw and normalized gene expression counts for all cells in all libraries. The same index was used for processing all individual libraries, so the genes found will be the same as in an invididual object.
   - After merging, the top 2000 high-variance genes are calculated by modeling variance within each library included in the merged object.


### PR DESCRIPTION
Closes #6 

This PR adds an outline for the next section of the results covering project downloads and introducing the merged object workflow. I briefly mention that you can download all data for a project as individual files and then mention the merged objects as an option. 

- I included a little bit about "why merged objects" right after mentioning that we offer them on the Portal. Is this the right place for this information? Is there something specific we should expand on? I wasn't going to go into any more detail outside of what we cover in [Getting started](https://github.com/AlexsLemonade/scpca-docs/blob/development/docs/getting_started.md#working-with-a-merged-scpca-object) and [the merged FAQs](https://github.com/AlexsLemonade/scpca-docs/blob/development/docs/faq.md#when-should-i-download-a-project-as-a-merged-object).
- I noticed that we don't include a step in the [merged workflow in Fig. 3](https://github.com/AlexsLemonade/scpca-paper-figures/blob/main/figures/compiled_figures/pngs/figure_3.png) for PCA and UMAP calculation? Do we feel like we need that?  