### PR TITLE
Add JNT edits to overview section of results

### DIFF
--- a/content/03.results.md
+++ b/content/03.results.md
@@ -3,27 +3,28 @@
 ## The Single-cell Pediatric Cancer Atlas Portal
 
 In March of 2022, the Childhood Cancer Data Lab launched the Single-cell Pediatric Cancer Atlas (ScPCA) Portal to make uniformly processed, summarized single-cell and single-nuclei RNA-seq data and de-identified metadata from pediatric tumor samples available for download.
-Today, the Portal contains data from 500 samples and over 50 tumor types.
-Data available on the Portal was obtained using two different mechanisms.
-Raw data was accepted from ALSF-funded investigators and processed using our open-source pipeline, `scpca-nf`, or investigators processed their raw data using `scpca-nf`, producing summarized gene expression data submitted for inclusion on the Portal.
+Data available on the Portal was obtained using two different mechanisms: raw data was accepted from ALSF-funded investigators and processed using our open-source pipeline, `scpca-nf`, or investigators processed their raw data using `scpca-nf` and submitted the output for inclusion on the Portal.
 
 All samples on the Portal include a core set of metadata obtained from investigators, including age, sex, diagnosis, subdiagnosis (if applicable), tissue location, and disease stage.
-Some investigators submitted additional metadata, such as treatment and tumor stage also found on the Portal.
-All submitted metadata was standardized as much as possible to maintain consistency across projects before adding to the Portal.
+Some investigators submitted additional metadata, such as treatment and tumor stage, which can also be found on the Portal.
+All submitted metadata was standardized to maintain consistency across projects before adding to the Portal.
 In addition to providing a human-readable value for the submitted metadata, we also provide an ontology term ID, if applicable.
+
+The Portal contains data from 500 samples and over 50 tumor types.
+<!-- TODO: Update numbers -->
 The total number of samples for each diagnosis is shown in Figure 1A, along with a breakdown of the proportion of samples from each disease stage within a diagnosis group.
 Figure 1A summarizes all samples from patient tumors or patient-derived xenografts currently available on the Portal.
-Along with the patient tumors, the Portal contains a handful of samples from human tumor cell lines.
+Along with the patient tumors, the Portal contains a small number of human tumor cell line samples.
 
-Each available sample has at minimum summarized gene expression data from either single-cell or single-nuclei RNA-seq.
+
+Each available sample has, at minimum, summarized gene expression data from either single-cell or single-nuclei RNA-seq.
 However, some samples include additional data, such as quantified data from tagging cells with Antibody-derived tags (ADT), like CITE-seq[@doi:10.1038/nmeth.4380], or multiplexing samples with hashtag oligonucleotides (HTO)[@doi:10.1186/s13059-018-1603-1].
 In some cases, multiple libraries from the same sample were collected to conduct either bulk RNA-seq or spatial transcriptomics.
 Downloading a sample on the Portal will include sequencing data from all associated libraries, including data from any additional modalities mentioned here.
-A summary of the number of samples with each additional modality is shown in Figure 1B, and a detailed summary of the total samples with each sequencing method broken-down by project, is available in Supplemental Table 1.
+A summary of the number of samples with each additional modality is shown in Figure 1B, and a detailed summary of the total samples with each sequencing method broken down by project is available in Supplemental Table 1.
 
-Samples on the Portal are organized by project, where each project is a collection of similar samples from a single investigator.
-Users can download all samples in a project or navigate to projects of interest and choose individual samples to download.
-To identify projects of interest, users can filter based on diagnosis, included modalities (e.g., CITE-seq, bulk RNA-seq), 10X Genomics version (e.g., 10Xv2, 10Xv3), and whether or not a project includes samples derived from patient-derived xenografts or cell lines.
+Samples on the Portal are organized by project, where each project is a collection of similar samples from an individual lab.
+Users can filter projects based on diagnosis, included modalities (e.g., CITE-seq, bulk RNA-seq), 10X Genomics version (e.g., 10Xv2, 10Xv3), and whether or not a project includes samples derived from patient-derived xenografts or cell lines.
 The project card displays an abstract, the total number of samples included, a list of diagnoses for all samples included in the Project, and links to any external information associated with the project, such as publications and links to external data, such as SRA or GEO (Figure 1C).
 The project card will also indicate the type(s) of sequencing performed, including the 10X Genomics kit version, the suspension type (cell or nucleus), and if additional sequencing is present, like bulk RNA-seq or multiplexing.
 


### PR DESCRIPTION
Stacked on #26. This is mostly copy editing and light reorganization. I've also added a TODO to remind us to update the number of samples as needed. I also think we could wait to talk about what downloads are available until Figure 3A, even though that doesn't show individual sample downloads. 

I will return more comments about how we're talking about Fig 1A-B on #26 in a moment. I'd probably merge this in and _then_ address those.