### PR TITLE
Table and Figure S1 legends

### DIFF
--- a/content/100.figure-table-legends.md
+++ b/content/100.figure-table-legends.md
@@ -1,5 +1,8 @@
 ## Figure Titles and Legends
 
+<br><br>
+
+<!-- Figure 1 -->
 ![**Overview of ScPCA Portal contents.**](https://raw.githubusercontent.com/AlexsLemonade/scpca-paper-figures/main/figures/compiled_figures/pngs/figure_1.png?sanitize=true){#fig:fig1 width="7in"}
 
 A. Barplots showing sample counts across four main cancer groupings in the ScPCA Portal, with each bar displaying the number of samples for each cancer type.
@@ -16,7 +19,9 @@ This project card is associated with project `SCPCP000009`.
 Project cards include information about the number of samples, technologies and modalities, additional sample metadata information, submitter-provided diagnoses, as well as submitter-provided abstract.
 Where available, submitter-provided citation information as well as other databases where this data has been deposited are also provided.
 
+<br><br>
 
+<!-- Figure 2 -->
 ![**Overview of the `scpca-nf` workflow.**](https://raw.githubusercontent.com/AlexsLemonade/scpca-paper-figures/main/figures/compiled_figures/pngs/figure_2.png?sanitize=true){#fig:fig2 width="7in"}
 
 A. An overview of `scpca-nf`, the primary workflow for processing single-cell and single-nuclei data for the ScPCA Portal.
@@ -46,7 +51,9 @@ F. UMAP embeddings of log-normalized RNA expression values where each cell is co
 G. UMAP embeddings of log-normalized RNA expression values for the top four most variable genes, colored by the given gene's expression.
 In the actual summary QC report, the top 12 most highly variable genes are shown.
 
+<br><br>
 
+<!-- Figure 3 -->
 ![**ScPCA Portal project download file structure and merged object workflow.**](https://raw.githubusercontent.com/AlexsLemonade/scpca-paper-figures/main/figures/compiled_figures/pngs/figure_3.png?sanitize=true){#fig:fig3 width="7in"}
 
 A. File download structure for an ScPCA Portal project download in `SingleCellExperiment` (`SCE`) format.
@@ -71,7 +78,9 @@ A grid of UMAPs is shown for each library in the merged object, with cells in th
 The UMAP is constructed from the merged object such that all libraries contribute an equal weight, but no batch correction was performed.
 The libraries pictured are a subset of libraries in the ScPCA project `SCPCP000003`.
 
+<br><br>
 
+<!-- Figure 4 -->
 ![**Cell type annotation in `scpca-nf`.**](https://raw.githubusercontent.com/AlexsLemonade/scpca-paper-figures/main/figures/compiled_figures/pngs/figure_4.png?sanitize=true){#fig:fig4 width="7in"}
 
 A. Expanded view of the process for adding cell type annotations within `scpca-nf`, as introduced in Figure {@fig:fig2}A.
@@ -88,6 +97,9 @@ The heatmap shown is from library `SCPCL000498`.
 
 ## Supplementary Figures and Tables
 
+<br><br>
+
+<!-- Table S1 -->
 **Table S1. Overview of ScPCA Portal Datasets.**
 This table provides descriptions and sample and library counts for each project in the ScPCA Portal.
 
@@ -99,7 +111,9 @@ This table provides descriptions and sample and library counts for each project 
 Due to additional sequencing modalities and/or multiplexing, projects may have more libraries than samples.
 All remaining columns give the number of libraries (as designated with `(L)`) with the given suspension type or additional modality.
 
+<br><br>
 
+<!-- Figure S1 -->
 ![**Results from benchmarking `alevin-fry` and `CellRanger` performance.**](https://raw.githubusercontent.com/AlexsLemonade/scpca-paper-figures/main/figures/compiled_figures/pngs/figure_s1.png?sanitize=true){#fig:figs1 tag="S1" width="7in"}
 
 Each panel compares metrics for six representative ScPCA libraries, including three single-cell and three single-nuclei suspensions, obtained from processing libraries with both `alevin-fry` and `CellRanger`.


### PR DESCRIPTION
Closes #32 
Towards #14 

This PR adds the legend for Table S1 and Figure S1. I included the link to display Fig S1 in the document, but not Table S1 b/c it's a table. But, we could add a markdown version of the table directly in here if we want..?

For Figure S1, I am looking for some recommendations to tighten up the wording. I feel it's a little repetitive now. I tried to ameliorate some of that by grouping some text that was similar to either all panels, or all panels B-D, but I think it can maybe be tightened up further. On the other hand, we could go the exact opposite route and not tighten up at all, but "loosen" the text to be more descriptive about each panel on its own terms!