### PR TITLE
Add JNT edits to CITE-seq section of results

### DIFF
--- a/content/03.results.md
+++ b/content/03.results.md
@@ -99,8 +99,7 @@ Although `scpca-nf` normalizes ADT counts, the workflow does not perform any dim
 The normalized ADT data is saved as an `altExp` within the processed `SingleCellExperiment` containing the normalized RNA data and is output to a `.rds` file with the suffix `_processed.rds`.
 All `.rds` files containing `SingleCellExperiment` objects and associated `altExp` objects, are converted to `AnnData` objects and exported as separate RNA (`_rna.hdf5`) and ADT (`_adt.hdf5`) AnnData objects. 
 
-If a library contains associated ADT data, the QC report output by `scpca-nf` will include an additional section with a summary of ADT-related statistics, such as how many cells express each ADT, and ADT-specific diagnostic plots
-(Supplemental Figure 2B-D).  
+If a library contains associated ADT data, the QC report output by `scpca-nf` will include an additional section with a summary of ADT-related statistics, such as how many cells express each ADT, and ADT-specific diagnostic plots (Supplemental Figure 2B-D).  
 As mentioned above, `scpca-nf` uses `DropletUtils::cleanTagCounts()` to calculate QC statistics for each cell using ADT expression but does not filter any cells from the object.
 We include plots summarizing the removal of low-quality cells based on RNA and ADT counts in the QC report (Supplemental Figure 2B).
 The first quadrant indicates which cells would be kept if the object was filtered on both RNA and ADT. 


### PR DESCRIPTION
Stacked on #37. I've only _really_ edited the CITE-seq section so far, but I did add headers and correct acronyms in the other sections. @allyhawkins, if you want to take a look at this and merge it before I look at the other sections, that'd be fine with me.