### PR TITLE
Add JNT edits to project download section

### DIFF
--- a/content/03.results.md
+++ b/content/03.results.md
@@ -147,37 +147,44 @@ The output includes the spot by gene matrix along with a summary report produced
 
 ## Downloading projects from the ScPCA Portal
 
-On the Portal, users can select to download data from individual samples or all data from an entire ScPCA project. 
+<!-- TODO: 
+⚠️ JNT thinks this level of repetition of facts covered in earlier sections is good.
+See what you think during your review. 
+-->
+On the Portal, users can select to download data from individual samples or all data from an entire ScPCA project.
 When downloading data for an entire project, users can choose between receiving the individual files for each sample (default) or one file containing the gene expression data and metadata for all samples in the project.
 Users also have the option to choose their desired format and receive the data as `SingleCellExperiment` (`.rds`) or `AnnData` (`.hdf5`) objects.
-If the download contains all samples as individual files, the download folder will include a sub-folder for each sample in the project (Figure 3A).
+
+For downloads with samples as individual files, the download folder will include a sub-folder for each sample in the project (Figure 3A).
 Each sample folder contains all three object types (unfiltered, filtered, and processed) as either `SingleCellExperiment` (`.rds`) or `AnnData` (`.hdf5`) objects and the QC report for all libraries from the given sample. 
 The objects house the summarized gene expression data and associated metadata for the library indicated in the filename. 
 
-Providing data for all libraries within a single file makes it easier for users to perform joint analyses on multiple samples simultaneously. 
-Specifically, these objects can be used for comparing gene-level metrics across multiple samples, such as differential expression analysis and gene set enrichment analysis.
+All project downloads include a metadata file, `single_cell_metadata.tsv`, containing relevant metadata for all samples, and a `README.md` with information about the contents of each download, contact and citation information, and terms of use for data downloaded from the Portal (Figure 3A-B).
+If the ScPCA project includes samples with bulk RNA-seq, two additional files are included: a gene by sample counts matrix (`bulk_quant.tsv`) with the quantified gene expression data for all samples in the project and a metadata file (`bulk_metadata.tsv`). 
+
+### Merged objects
+
+Providing data for all libraries within a single file makes it easier for users to perform joint gene-level analyses, such as differential expression or gene set enrichment analyses, on multiple samples simultaneously. 
 Therefore, we make a single, merged object available for each project containing all raw and normalized gene expression data and metadata for all single-cell and single-nuclei RNA-seq libraries within a given ScPCA project.
 The data in the merged object has simply been combined, and no batch-corrected or integrated data is included. 
-If downloading data from a ScPCA project as a single, merged file, the download will include a single `.rds` or `.hdf5` file, depending on the chosen file format, a summary report for the merged object, and a folder with all individual QC and cell type reports for each library found in the merged object (Figure 3B).
-
-Regardless of downloading all samples in a project as individual files or as a merged object, the download will include a metadata file, `single_cell_metadata.tsv`, containing relevant metadata for all samples, and a `README.md` with information about the contents of each download, contact and citation information, and terms of use for data downloaded from the Portal.
-If the chosen ScPCA project has samples with bulk RNA-seq, two additional files are included: a sample by gene counts matrix (`bulk_quant.tsv`) with the quantified gene expression data for all samples in the project, and a metadata file (`bulk_metadata.tsv`). 
+If downloading data from a ScPCA project as a single, merged file, the download will include a single `.rds` or `.hdf5` file, a summary report for the merged object, and a folder with all individual QC and cell type reports for each library found in the merged object (Figure 3B).
 
 To build the merged objects, we created an additional stand-alone workflow for merging the output from `scpca-nf`, `merge.nf` (Figure 3C).
 `merge.nf` takes as input the processed `SingleCellExperiment` objects output by `scpca-nf` for all single-cell and single-nuclei libraries included in a given ScPCA project.
 The gene expression data stored in all `SingleCellExperiment` objects are then merged to produce a single merged gene by cell counts matrix containing all cells from all libraries and all shared genes.
-All objects on the Portal were quantified using the same index with the same set of genes, so the genes found in the merged object will be the same as those found in each individual object.
-Any metadata found in the individual processed objects is also merged (e.g., `colData`, `rowData`, and `metadata`). 
+The genes available in the merged object will be the same as those in each individual object, as all objects on the Portal were quantified using the same index.
+Any metadata found in the individual processed `SingleCellExperiment` objects are also merged (e.g., `colData`, `rowData`, and `metadata`). 
 The merged normalized counts matrix is then used to select high-variance genes in a library-aware manner before performing dimensionality reduction with both PCA and UMAP.
 `merge.nf` outputs the merged and processed object as a `SingleCellExperiment` object.
 
+We also account for additional modalities in `merge.nf`.
 If at least one library in a project contains ADT data, the raw and normalized ADT data are also merged and saved as an `altExp` in the merged `SingleCellExperiment` object. 
 If any libraries in a project are multiplexed, the HTO data is not merged and is not included in the merged object. 
 All merged `SingleCellExperiment` objects are converted to `AnnData` objects and exported as `.hdf5` files. 
 If the merged object contains an `altExp` with merged ADT data, two `AnnData` objects are exported to create separate RNA (`_rna.hdf5`) and ADT (`_adt.hdf5`) objects.
 
 `merge.nf` outputs a summary report for each merged object, which includes a set of tables summarizing the types of samples and libraries included in the project, such as types of diagnosis, and a faceted UMAP showing all cells from all libraries. 
-In the UMAP each panel represents a different library included in the merged object, with all cells from the specified library shown in color, while all other cells are gray. 
+In the UMAP, each panel represents a different library included in the merged object, with all cells from the specified library shown in color, while all other cells are gray. 
 An example of this UMAP showing a subset of libraries from a ScPCA project is available in Figure 3D. 
 
 


### PR DESCRIPTION
Stacked on #56. The biggest change here is that I'm rearranging so that everything that applies to both individual files and merged downloads is explained together at the beginning of the section. I'm also adding an H3 header to create a section on the merged objects. 

I'm not 100% happy with what I've done here, but I think it should be good enough to get us to the round-robin-style editing phase. I also added a little TODO with instructions for reviewers when we get there.