### PR TITLE
Add JNT edits to cell type section of results

### DIFF
--- a/content/03.results.md
+++ b/content/03.results.md
@@ -204,7 +204,7 @@ This requires two additional reference files as input to the workflow: a classif
 `SingleR::trainSingleR()` was used to build a classification model from the provided `BlueprintEncodeData` dataset and create the required `SingleR` input for `scpca-nf`.
 The classification model and processed `SingleCellExperiment` were used as input for `SingleR::classifySingleR()`, resulting in annotations for all cells and an associated score matrix. 
 <!-- TODO: Check that I've retained meaning + correct orientation of score matrix in next sentence -->
-The `SingleR` cell by possible cell type score matrix and each possible cell type and the assigned cell types are added to the processed `SingleCellExperiment` object output by `scpca-nf`. 
+The score matrix containing a score for all cells and each possible cell type and the assigned cell types are added to the processed `SingleCellExperiment` object output by `scpca-nf`. 
 Simultaneously, processed `SingleCellExperiment` objects are converted to `AnnData` objects for classification with `CellAssign`. 
 `CellAssign` uses the converted `AnnData` object and the marker gene matrix to train a model and predict the most likely cell type from the possible cell types in the marker gene matrix. 
 The prediction matrix containing a probability for each cell and all possible cell types and the assigned cell types are added to the processed `SingleCellExperiment` object output by `scpca-nf`. 


### PR DESCRIPTION
Stacked on #63. Most of my edits pertain to the early paragraphs, which address the following in https://github.com/AlexsLemonade/ScPCA-manuscript/pull/63#issue-2164289201:

> The biggest thing I'm unsure of is the first paragraph. Is this content what we're looking for regarding explaining why cell types? Or are there things missing?

I also added a couple TODOs in later paragraphs to track adding citations and text I think could be made more clear.