### PR TITLE
Methods section for metadata and ontologies

### DIFF
--- a/content/04.methods.md
+++ b/content/04.methods.md
@@ -125,7 +125,7 @@ If cell types were obtained from the submitter of the dataset, the submitter-pro
 Cell type labels determined by both `SingleR`[@doi:10.1038/s41590-018-0276-y] and `CellAssign`[@doi:10.1038/s41592-019-0529-1] were added to processed `SingleCellExperiment` objects.
 
 To build the references used for assigning cell types, a separate workflow within `scpca-nf` was run, `build-celltype-index.nf`.
-For `SingleR` we used the `BlueprintEncodeData` from the `celldex` package [@doi:10.3324/haematol.2013.094243; @doi:10.1038/nature11247;@doi:10.18129/B9.bioc.celldex]  to train the `SingleR` classification model with `SingleR::trainSingleR()`.
+For `SingleR` we used the `BlueprintEncodeData` from the `celldex` package [@doi:10.3324/haematol.2013.094243; @doi:10.1038/nature11247; @doi:10.18129/B9.bioc.celldex]  to train the `SingleR` classification model with `SingleR::trainSingleR()`.
 The model and the processed `SingleCellExperiment` object were input to `SingleR::classifySingleR()`.
 The `SingleR` output of cell type annotations and a score matrix for each cell and all possible cell types were added to the processed `SingleCellExperiment` object output.
 To evaluate confidence in `SingleR` cell type assignments, we also calculated a delta median statistic for each cell by subtracting the median cell type score from the maximum score for that cell [@url:https://bioconductor.org/books/release/SingleRBook/annotation-diagnostics.html#based-on-the-deltas-across-cells].


### PR DESCRIPTION
Closes #50 
Stacked on #61 

Here I'm adding a section to the methods on metadata, including ontology assignments. I added this section below the data processing and generation and above any of processing related methods. 

I mentioned that metadata is standardized as much as possible across projects and list out the ontology terms that were assigned. I provided any relevant details on how exactly we assigned terms, but let me know if we should include more detail? 

I'm requesting @jaclyn-taroni since she was the most involved other than me in the ontology assignment and metadata cleaning. 