### PR TITLE
Add S3, S4, and S5 legends

### DIFF
--- a/content/100.figure-table-legends.md
+++ b/content/100.figure-table-legends.md
@@ -143,7 +143,7 @@ Distributions reflect broad agreement between platforms in the total number of g
 
 
 <!-- Figure S3 -->
-![**Processing other sequencing modalities `scpca-nf`.**](https://raw.githubusercontent.com/AlexsLemonade/scpca-paper-figures/main/figures/compiled_figures/pngs/figure_s3.png?sanitize=true){#fig:figs3 tag="S3" width="7in"}
+![**Processing other sequencing modalities with `scpca-nf`.**](https://raw.githubusercontent.com/AlexsLemonade/scpca-paper-figures/main/figures/compiled_figures/pngs/figure_s3.png?sanitize=true){#fig:figs3 tag="S3" width="7in"}
 
 A. Overview of the bulk RNA-Seq workflow.
 A set of FASTQ files from libraries sequenced with bulk RNA-seq are provided as input.


### PR DESCRIPTION
Towards #14 

This PR stubs out the remaining supplementary figures (including titles and the figure links). But, I've added legends _only_ for S3-S5; S2 is coming up in a stacked PR since it's a much bigger one. I also added explicit tags for the main text figures, because why not. 

I'm curious to hear thoughts on how I've titled S2 and S3 as well!