### PR TITLE
Add legend for Table S2

### DIFF
--- a/content/100.figure-table-legends.md
+++ b/content/100.figure-table-legends.md
@@ -112,6 +112,19 @@ Due to additional sequencing modalities and/or multiplexing, projects may have m
 All remaining columns give the number of libraries (as designated with `(L)`) with the given suspension type or additional modality.
 
 <br><br>
+<!-- Table S2 -->
+**Table S2. Summary of references used for cell type annotation with `CellAssign`.**
+This table provides a summary of the references used for assigning cell types for ScPCA projects using `CellAssign`. 
+All references were built using all cell types from a specified set of organs present in `PanglaoDB`'s marker gene list.
+
+`scpca_project_id`: ScPCA project unique identifier.
+`Diagnoses`: Full set of diagnoses for all samples associated with the project.
+`ScPCA reference name`: Name used to describe the custom reference.
+`PanglaoDB organs included in reference`: A list of all organs included in the reference with names of organs corresponding to organs listed in `PanglaoDB`. 
+The reference includes marker genes for all cell types present in each organ. 
+
+<br><br>
+
 
 <!-- Figure S1 -->
 ![**Results from benchmarking `alevin-fry` and `CellRanger` performance.**](https://raw.githubusercontent.com/AlexsLemonade/scpca-paper-figures/main/figures/compiled_figures/pngs/figure_s1.png?sanitize=true){#fig:figs1 tag="S1" width="7in"}
@@ -186,18 +199,7 @@ The workflow directly returns the results from running `spaceranger` without any
 
 <br><br>
 
-<!-- Table S2 -->
-**Table S2. Summary of references used for cell type annotation with `CellAssign`.**
-This table provides a summary of the references used for assigning cell types for ScPCA projects using `CellAssign`. 
-All references were built using all cell types from a specified set of organs present in `PanglaoDB`'s marker gene list.
 
-`scpca_project_id`: ScPCA project unique identifier.
-`Diagnoses`: Full set of diagnoses for all samples associated with the project.
-`ScPCA reference name`: Name used to describe the custom reference.
-`PanglaoDB organs included in reference`: A list of all organs that were selected to be included in the reference. 
-Marker genes for all cell types for each organ listed were included when constructing the reference. 
-
-<br><br>
 
 <!-- Figure S4 -->
 ![**Assessment of cell type annotation quality.**](https://raw.githubusercontent.com/AlexsLemonade/scpca-paper-figures/main/figures/compiled_figures/pngs/figure_s4.png?sanitize=true){#fig:figs4 tag="S4" width="7in"}


### PR DESCRIPTION
Closes #78 

Here I'm adding in the legend for [Table S2](https://github.com/AlexsLemonade/scpca-paper-figures/blob/main/tables/TableS2_cellassign-ref-summary.tsv). I added this in the order that the supplemental figures/ tables come up, but we could also group so that all tables are first and then all figures? 