### PR TITLE
Update cell type results section to include information on choosing cell type methods/ refs

### DIFF
--- a/content/03.results.md
+++ b/content/03.results.md
@@ -197,8 +197,8 @@ To identify the most appropriate reference to use with `SingleR`, we annotated 
 The output from `SingleR` includes a score matrix containing a score for each cell and all possible cell types found in the reference, where higher scores are associated with assigned cell types. 
 We calculated the delta median statistic for each cell in the dataset, subtracting the median score from the highest score. 
 The delta median statistic helps evaluate how confident `SingleR` is in assigning each cell to a specific cell type, where low delta median values indicate ambiguous assignments and high delta median values indicate confident assignments [@url:https://bioconductor.org/books/release/SingleRBook/annotation-diagnostics.html#based-on-the-deltas-across-cells].
-<!-- TODO: "highest or equivalent...distribution" implies to me that we tested it... and that is not what we are presenting -->
-We found that the `BlueprintEncodeData` reference [@doi:10.3324/haematol.2013.094243; @doi:10.1038/nature11247], which includes a variety of normal cell types and provides both the human-readable cell name and cell ontology identifier [@url:https://www.ebi.ac.uk/ols4/ontologies/cl], had a consistently high delta median distribution across samples from different disease types (Supplemental Figure 4).
+<!-- TODO: ⚠️ For review - What do you think of the next sentence? -->
+We found that the `BlueprintEncodeData` reference [@doi:10.3324/haematol.2013.094243; @doi:10.1038/nature11247], which includes a variety of normal cell types and provides both the human-readable cell name and cell ontology identifier [@url:https://www.ebi.ac.uk/ols4/ontologies/cl], tended to perform best or at least similarly to other references across samples from different disease types using this measure (Supplemental Figure 4).
 Based on these findings, we used the `BlueprintEncodeData` reference to annotate cells from all libraries on the Portal, as using a single reference is potentially valuable for cross-project analyses.
 
 In contrast, `CellAssign` is a marker-gene-based annotation method that requires a binary matrix with all cell types and all associated marker genes as the reference. 


### PR DESCRIPTION
Closes #70 

This PR edits the existing cell type section to include two sections, one for choosing cell type methods and references, and the other for the workflow. I included a description of the two new figures we have for SingleR and CellAssign. I will note that the order of appearance here is different than the current figure number order, so I think we need to switch what is currently S4/S5 with S6/S7. 

