### PR TITLE
Update figure legend for multiplexed overview to account for HTO as input to alevin-fry

### DIFF
--- a/content/100.figure-table-legends.md
+++ b/content/100.figure-table-legends.md
@@ -154,7 +154,7 @@ Distributions reflect broad agreement between platforms in the total number of g
 A. Overview of the `scpca-nf` workflow for processing libraries with CITE-seq or antibody-derived tag (ADT) derived data.
 The workflow mirrors that shown in Figure {@fig:fig2}A with several differences accounting for the presence of ADT data.
 First, both an RNA and ADT FASTQ file are required as input to `alevin-fry`, along with a TSV file containing infomation about ADT barcodes.
-The gene-by-cell and ADT-by-cell count matrices are produced and read into `R` to create a `SingleCellExperiment` (SCE) object.
+The gene by cell and ADT by cell count matrices are produced and read into `R` to create a `SingleCellExperiment` (SCE) object.
 Second, during post-processing, statistics are calculated to filter cells based on ADT counts, but the filter is not applied.
 ADT counts are also normalized and included in the `Processed SCE Object`.
 Third, the summary QC report will include a `CITE-seq` section with additional information about ADT-level processing.
@@ -174,7 +174,8 @@ D. UMAP embeddings of log-normalized RNA expression values where each cell is co
 
 E. Overview of the `scpca-nf` workflow for multiplexed libraries.
 The workflow mirrors that shown in Figure {@fig:fig2}A with several differences accounting for the presence of multiplexed data.
-First, a TSV file providing information about library pools is required as input to `alevin-fry` along with the RNA FASTQ file.
+First, both an RNA and HTO FASTQ file are required as input to `alevin-fry`, along with a TSV file providing information about library pools.
+The gene by cell and HTO by cell count matrices are produced and read into `R` to create a `SingleCellExperiment` (SCE) object.
 Second, in parallel, the RNA FASTQ file, the HTO FASTQ file, and, if available, a corresponding Bulk RNA FASTQ file for each sample present in the multiplexed library are provided to a demultiplexing subprocess.
 The workflow calculates demultiplexing results based on HTO counts, as well as genetic demultiplexing results if the library has corresponding bulk RNA FASTQ files.
 Demultiplexing results are stored in all exported `SCE` objects (`Unfiltered`, `Filtered`, and `Processed`), but libraries themselves are not demultiplexed.


### PR DESCRIPTION
Following the changes made to the figure for the multiplexed overview in https://github.com/AlexsLemonade/scpca-paper-figures/pull/84, this updates the figure legend to match. Mostly, I just mentioned including the HTO FASTQ as an input file for alevin-fry. 

Also, I missed a few hyphens in gene by cell that we were still using and removed those here. The rest of the text we are just referring to matrices as `gene by cell` not `gene-by-cell`. 