### PR TITLE
Add author list and metadata for manuscript

### DIFF
--- a/content/metadata.yaml
+++ b/content/metadata.yaml
@@ -82,7 +82,7 @@ authors:
     name: Arkadii Yakovets
     initials: AY
     orcid: TODO
-    email: TODO
+    email: ark@cho.red
     contributions:
       - TODO
     affiliations:
@@ -116,7 +116,7 @@ authors:
   - github: envest
     name: Steven M. Foltz
     initials: SMF
-    email: steven.foltz@pennmedicine.upenn.edu
+    email: foltzs@chop.edu
     orcid: 0000-0002-9526-8194
     contributions:
       - TODO


### PR DESCRIPTION
Closes #82 

Here I filled in the `metadata.yaml` file for the manuscript to provide the title, keywords, and list of authors. I used the same title that we used for the poster and the AACR abstract, but let me know if we should change it. 

For the authors, I have most everything, but I am missing the occasional orcid ids and emails. I left TODOs next to things that I don't have, but we could also remove those things for those authors? I wasn't sure if we needed emails for everyone, but I was following what was done for OpenPBTA and it looks like most fields were filled out for all authors. 

The one thing that I didn't do was fill in the contributions. I think we can do that in a separate PR. 