### PR TITLE
Add spell check output in comment

### DIFF
--- a/.github/workflows/manubot.yaml
+++ b/.github/workflows/manubot.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - jashapiro/*
   pull_request:
     branches:
       - main
@@ -118,3 +119,13 @@ jobs:
             This build is associated with commit ${{ env.TRIGGERING_SHA_7 }}.
 
             [Manuscript build](${{ steps.artifact-upload-step.outputs.artifact-url }})
+      - name: Fail if there are spelling errors
+        run: |
+          # only check the the spelling locations, which skips the preambles/authors
+          if [ -s output/spelling-error-locations.txt ]; then
+            echo "No spelling errors in text"
+          else
+            echo "Spelling errors (some may be in the author list):"
+            cat output/spelling_errors.txt
+            exit 1
+          fi

--- a/.github/workflows/manubot.yaml
+++ b/.github/workflows/manubot.yaml
@@ -109,6 +109,15 @@ jobs:
           CI_BUILD_WEB_URL: https://github.com/${{ github.repository }}/commit/${{ github.sha }}/checks
           CI_JOB_WEB_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: bash ci/deploy.sh
+      - name: Count spelling errors
+        run: |
+          # count the number of spelling errors using the spelling-error-locations.txt file
+          # this file does not include preamble or author list spelling errors
+          if [ -s output/spelling-error-locations.txt ]; then
+            echo "SPELLING_ERRORS=$(wc -l < output/spelling-error-locations.txt)" >> $GITHUB_ENV
+          else
+            echo "SPELLING_ERRORS=0" >> $GITHUB_ENV
+          fi
       - name: Post artifact comment to PR
         if: github.event_name == 'pull_request'
         uses: peter-evans/create-or-update-comment@v4
@@ -119,12 +128,14 @@ jobs:
             This build is associated with commit ${{ env.TRIGGERING_SHA_7 }}.
 
             [Manuscript build](${{ steps.artifact-upload-step.outputs.artifact-url }})
-      - name: Fail if there are spelling errors
+
+            **There were ${{ env.SPELLING_ERRORS }} spelling errors.**
+            Check the build link above for details.
+
+      - name: Fail for spelling errors in manual builds
+        # if: github.event_name == 'workflow_dispatch' && env.SPELLCHECK == 'true'
         run: |
-          # only check the the spelling locations, which skips the preambles/authors
-          if [ -s output/spelling-error-locations.txt ]; then
-            echo "No spelling errors in text"
-          else
+          if [ $SPELLING_ERRORS ]; then
             echo "Spelling errors (some may be in the author list):"
             cat output/spelling_errors.txt
             exit 1

--- a/.github/workflows/manubot.yaml
+++ b/.github/workflows/manubot.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - jashapiro/*
   pull_request:
     branches:
       - main
@@ -133,10 +132,10 @@ jobs:
             Check the build link above for details.
 
       - name: Fail for spelling errors in manual builds
-        # if: github.event_name == 'workflow_dispatch' && env.SPELLCHECK == 'true'
+        if: github.event_name == 'workflow_dispatch' && env.SPELLCHECK == 'true'
         run: |
           if [ $SPELLING_ERRORS ]; then
             echo "Spelling errors (some may be in the author list):"
-            cat output/spelling_errors.txt
+            cat output/spelling-errors.txt
             exit 1
           fi

--- a/build/assets/custom-dictionary.txt
+++ b/build/assets/custom-dictionary.txt
@@ -15,6 +15,7 @@ benchmarking
 cDNA
 celldex
 CELLxGENE
+curation
 customizations
 CZI
 CZI's
@@ -101,3 +102,14 @@ unspliced
 Visium
 wikidata
 xenografts
+AGH
+JAS
+SJS
+DSM
+DVP
+NI
+AY
+KGW
+CJB
+JO
+JNT


### PR DESCRIPTION
closes #96

Since spelling errors due to names and such seem to be common, I decided that rather than making the workflow fail on spelling errors, it would be better to just print out the number of spelling errors in the artifact comment, so that is what I have done here. 

I count the total number of errors by their locations, not the number of indepdendent errors. This was partly because I found that the locations file only includes the content files, while the `spelling-errors.txt` file also included errors in the frontmatter, which are mostly names. 

I also implemented failure for manual triggers, but I don't expect that to be used much. 

The first build here should demonstrate the output, if it is working.