### PR TITLE
Clarify section describing demultiplexing

### DIFF
--- a/content/04.methods.md
+++ b/content/04.methods.md
@@ -85,8 +85,8 @@ The normalized ADT data are available in the `altExp` of the processed object.
 
 ### Processing HTO data from multiplexed libraries
 
-Although we did not perform any demultiplexing of samples within a multiplexed library, we did apply three different demultiplexing methods.
-Results from all three methods are included in the filtered and processed `SingleCellExperiment` objects along with the HTO counts data.
+To identify which cells come from which samples in a multiplexed library, we applied three different demultiplexing methods, genetic demultiplexing and HTO demultiplexing using `DropletUtils::hashedDrops()` and `Seurat::HTODemux()`.
+We do not actually separate the samples within a multiplexed library into separate `SingleCellExperiment` objects, so each multiplexed library contains the counts data from all samples and the results from all three demultiplexing methods.
 
 #### Genetic demultiplexing
 


### PR DESCRIPTION
Closes #109 

Here I edited the methods section on processing the HTO data. I attempted to clarify that we apply three methods to identify which cells may belong to which sample and then emphasize that we do not actually separate the samples into their own objects. Instead, the multiplexed library contains counts data from all samples that were multiplexed together and the results from demultiplexing. 

Does this help clarify what we did? In general, we do not separate the cells from each sample, but we provide the results so that users can separate if they so desire. 