### PR TITLE
Make a note in the text about not providing merged objects for large projects

### DIFF
--- a/content/03.results.md
+++ b/content/03.results.md
@@ -167,7 +167,7 @@ Where possible, library-, cell- and gene-specific metadata found in the individu
 The merged normalized counts matrix is then used to select high-variance genes in a library-aware manner before performing dimensionality reduction with both PCA and UMAP.
 `merge.nf` outputs the merged and processed object as a `SingleCellExperiment` object.
 The more samples that are included in a merged object, the larger the object, and the more difficult it is to work with that object in R or Python.
-Therefore, we do not provide merged objects for projects with more than 50 samples due to size constraints.
+Therefore, we do not provide merged objects for projects with more than 50 samples.
 
 We also account for additional modalities in `merge.nf`.
 If at least one library in a project contains ADT data, the raw and normalized ADT data are also merged and saved as an `altExp` in the merged `SingleCellExperiment` object.

--- a/content/03.results.md
+++ b/content/03.results.md
@@ -166,6 +166,8 @@ The genes available in the merged object will be the same as those in each indiv
 Where possible, library-, cell- and gene-specific metadata found in the individual processed `SingleCellExperiment` objects are also merged.
 The merged normalized counts matrix is then used to select high-variance genes in a library-aware manner before performing dimensionality reduction with both PCA and UMAP.
 `merge.nf` outputs the merged and processed object as a `SingleCellExperiment` object.
+The more samples that are included in a merged object, the larger the object, and the more difficult it is to work with that object in R or Python.
+Therefore, we do not provide merged objects for projects with more than 50 samples due to size constraints.
 
 We also account for additional modalities in `merge.nf`.
 If at least one library in a project contains ADT data, the raw and normalized ADT data are also merged and saved as an `altExp` in the merged `SingleCellExperiment` object.

--- a/content/04.methods.md
+++ b/content/04.methods.md
@@ -156,6 +156,7 @@ The top 50 principal components were selected and used to calculate UMAP embeddi
 
 If any libraries included in the ScPCA project contain additional ADT data, the ADT data are also merged and stored in the `altExp` slot of the merged `SingleCellExperiment` object.
 By contrast, if any libraries included in the ScPCA project are multiplexed and contain HTO data, no merged object is created.
+Merged objects were not created for any projects with more than 50 samples due to size constraints.
 
 ### Converting SingleCellExperiment objects to AnnData objects
 

--- a/content/04.methods.md
+++ b/content/04.methods.md
@@ -156,7 +156,7 @@ The top 50 principal components were selected and used to calculate UMAP embeddi
 
 If any libraries included in the ScPCA project contain additional ADT data, the ADT data are also merged and stored in the `altExp` slot of the merged `SingleCellExperiment` object.
 By contrast, if any libraries included in the ScPCA project are multiplexed and contain HTO data, no merged object is created.
-Merged objects were not created for any projects with more than 50 samples due to size constraints.
+Merged objects were not created for projects with more than 50 samples because of the computational resources that would be required for working with those objects.
 
 ### Converting SingleCellExperiment objects to AnnData objects
 


### PR DESCRIPTION
Closes #116 

I added a note to the methods and the results about not providing merged objects for projects with > 50 samples. Maybe we don't need as much detail as I added to the results though and could simplify to one sentence? 