### PR TITLE
Update formatting for URL references

### DIFF
--- a/content/manual-references.json
+++ b/content/manual-references.json
@@ -1,22 +1,46 @@
 [
 {
-  "id": "url:https://github.com/manubot/rootstock",
+  "id": "url:https://cells.ucsc.edu/",
   "type": "webpage",
-  "URL": "https://github.com/manubot/rootstock",
-  "title": "manubot/rootstock GitHub repository",
+  "URL": "https://cells.ucsc.edu/",
+  "title": "UCSC Cell Browser"
+},
+{
+  "id": "url:https://www.ebi.ac.uk/ols4/ontologies/hancestro",
+  "type": "webpage",
+  "URL": "https://www.ebi.ac.uk/ols4/ontologies/hancestro",
+  "title": "Ontology Lookup Service (OLS) - Hancestro"
+},
+{
+  "id": "url:https://www.ebi.ac.uk/ols4/ontologies/hsapdv",
+  "type": "webpage",
+  "URL": "https://www.ebi.ac.uk/ols4/ontologies/hsapdv",
+  "title": "Ontology Lookup Service (OLS) - HsapDv"
+},
+{
+  "id": "url:https://www.ebi.ac.uk/ols4/ontologies/mondo",
+  "type": "webpage",
+  "URL": "https://www.ebi.ac.uk/ols4/ontologies/mondo",
+  "title": "Ontology Lookup Service (OLS) - MONDO"
+},
+{
+  "id": "url:https://www.ebi.ac.uk/ols4/ontologies/pato",
+  "type": "webpage",
+  "URL": "https://www.ebi.ac.uk/ols4/ontologies/pato",
+  "title": "Ontology Lookup Service (OLS) - PATO"
+},
+{
+  "id": "url:https://www.ebi.ac.uk/ols4/ontologies/uberon",
+  "type": "webpage",
+  "URL": "https://www.ebi.ac.uk/ols4/ontologies/uberon",
+  "title": "Ontology Lookup Service (OLS) - UBERON"
+},
+{
+  "id": "url:https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/3.0.0/schema.md",
+  "type": "webpage",
+  "abstract": "Code and documentation for the curation of cellxgene datasets - chanzuckerberg/single-cell-curation",
   "container-title": "GitHub",
-  "issued": {
-    "date-parts": [
-      [
-        2019
-      ]
-    ]
-  },
-  "author": [
-    {
-      "given": "Daniel",
-      "family": "Himmelstein"
-    }
-  ]
+  "title": "CZI Single cell curation schema 3.0.0",
+  "URL": "https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/3.0.0/schema.md"
 }
 ]

--- a/content/manual-references.json
+++ b/content/manual-references.json
@@ -39,7 +39,7 @@
   "id": "url:https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/3.0.0/schema.md",
   "type": "webpage",
   "abstract": "Code and documentation for the curation of cellxgene datasets - chanzuckerberg/single-cell-curation",
-  "container-title": "GitHub",
+  "container-title": "CZI Cellxgene",
   "title": "CZI Single cell curation schema 3.0.0",
   "URL": "https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/3.0.0/schema.md"
 }


### PR DESCRIPTION
Closes #75 

There were a few references that had some weird formatting, specifically the OLS links, the CZI schema, and the UCSC cell browser. I added manual reference data for those, in particular, I made sure that each of the OLS links says what ontology term id is linked in the title. 