### PR TITLE
Update diagnosis and disease timing numbers

### DIFF
--- a/.github/workflows/manubot.yaml
+++ b/.github/workflows/manubot.yaml
@@ -86,9 +86,6 @@ jobs:
           activate-environment: manubot
           environment-file: build/environment.yml
           auto-activate-base: false
-          miniforge-variant: Mambaforge
-          miniforge-version: "latest"
-          use-mamba: true
       - name: Install Spellcheck
         if: env.SPELLCHECK == 'true'
         run: bash ci/install-spellcheck.sh

--- a/content/03.results.md
+++ b/content/03.results.md
@@ -16,10 +16,10 @@ The Portal contains data from 700 samples and 55 tumor types [@doi:10.1016/j.dev
 <!-- TODO: Update numbers -->
 Figure {@fig:fig1}A summarizes all samples from patient tumors and patient-derived xenografts currently available on the Portal.
 The total number of samples for each diagnosis is shown, along with the proportion of samples from each disease stage within a diagnosis group.
-The largest number of samples found on the Portal were obtained from patients with leukemia (n = 191).
-The Portal also includes samples from brain and central nervous system tumors (n = 166), sarcoma and soft tissue tumors (n = 68), and a variety of other solid tumors (n = 86).
-Most samples were collected at initial diagnosis (n = 426), with a smaller number of samples collected either at recurrence (n = 67), during progressive disease (n = 12), or post-mortem (n = 5).
-Along with the patient tumors, the Portal contains a small number of human tumor cell line samples (n = 4).
+The largest number of samples found on the Portal were obtained from patients with leukemia (n = 216).
+The Portal also includes samples from sarcoma and soft tissue tumors (n = 194), brain and central nervous system tumors (n = 167), and a variety of other solid tumors (n = 117).
+Most samples were collected at initial diagnosis (n = 521), with a smaller number of samples collected either at recurrence (n = 129), during progressive disease (n = 13), during or after treatment (n = 11), or post-mortem (n = 5).
+Along with the patient tumors, the Portal contains a small number of human tumor cell line samples (n = 6).
 
 Each of the available samples contains summarized gene expression data from either single-cell or single-nuclei RNA sequencing.
 However, some samples also include additional data, such as quantified expression data from tagging cells with antibody-derived tags (ADT), such as CITE-seq antibodies [@doi:10.1038/nmeth.4380], or multiplexing samples with hashtag oligonucleotides (HTO) [@doi:10.1186/s13059-018-1603-1] prior to sequencing.

--- a/content/100.figure-table-legends.md
+++ b/content/100.figure-table-legends.md
@@ -10,7 +10,7 @@ B. Barplot showing sample counts across types of modalities present in the ScPCA
 All samples in the portal are shown under the "All Samples" heading.
 Samples under the "Samples with additional modalities" heading represent a subset of the total samples with the given additional modality.
 Colors shown for each additional modality indicate the suspension type used, either single-cell or single-nuclei RNA-seq.
-For example, 75 single-cell samples and 43 single-nuclei samples have accompanying Bulk RNA-seq data.
+For example, 75 single-cell samples and 67 single-nuclei samples have accompanying Bulk RNA-seq data.
 
 C. Example of a project card as displayed on the "Browse" page of the ScPCA Portal.
 This project card is associated with project `SCPCP000009` [@doi:10.21203/rs.3.rs-2517703/v1; @doi:10.21203/rs.3.rs-2517758/v1].


### PR DESCRIPTION
Closes #124 

Here I'm just updating the text to have the updated numbers for diagnoses and disease timing. The updated numbers are from the [tables in `scpca-paper-figures`](https://github.com/AlexsLemonade/scpca-paper-figures/tree/main/manuscript-numbers). 

I also found a spot in the legend that needed to be updated based on the new numbers. 