### PR TITLE
Add consensus cell type figure legends

### DIFF
--- a/build/assets/custom-dictionary.txt
+++ b/build/assets/custom-dictionary.txt
@@ -39,6 +39,10 @@ genomic
 genotype
 genotypes
 github
+glioma
+gliomas
+granulocyte
+granulocytes
 GRCh
 Hancestro
 HCA
@@ -63,6 +67,7 @@ microarray
 microenvironment
 MONDO
 mortem
+myeloid
 NCBI
 NCBITaxon
 Nextflow

--- a/content/100.figure-table-legends.md
+++ b/content/100.figure-table-legends.md
@@ -96,10 +96,10 @@ The heatmap shown is from library `SCPCL000498` [@doi:10.1016/j.devcel.2022.04.0
 ![**Consensus cell type annotations in Brain and CNS tumors.**](https://raw.githubusercontent.com/AlexsLemonade/scpca-paper-figures/main/figures/compiled_figures/pngs/figure_5.png?sanitize=true){#fig:fig5 tag="5" width="7in"}
 
 A. Dot plot showing expression of cell-type-specific marker genes across all libraries from brain and central nervous system (CNS) tumors.
-Expression is shown for each broad consensus cell type annotation.
-The y-axis displays the consensus cell type observed across libraries, with the total number of cells indicated in parentheses.
-The x-axis displays marker genes, determined by `CellMarker2.0` [@doi:10.1093/nar/gkac947], used for consensus cell type validation for each cell types shown along the top annotation bar.
-Dots are colored by mean gene expression across libraries and sized proportionally to the percent of libraries they are observed in, out of all cells in brain and CNS tumor libraries.
+Expression is shown for each broad cell type annotation, where each broad cell type annotation is a collection of similar consensus cell type annotations. 
+The y-axis displays the broad consensus cell type observed across libraries, with the total number of cells indicated in parentheses.
+The x-axis displays marker genes, determined by `CellMarker2.0` [@doi:10.1093/nar/gkac947], used for consensus cell type validation for each cell type shown along the top annotation bar.
+Dots are colored by mean gene expression across libraries and sized proportionally to the percent of libraries they are observed in, out of all cells with the same broad cell type annotation in brain and CNS tumor libraries.
 
 B. Barplot showing the percentage of each broad consensus cell type annotation across libraries of brain and CNS tumors, separated into high-grade (left panel) and low-grade (right panel) glioma diagnoses.
 
@@ -247,10 +247,10 @@ A value of 1 means that there is complete overlap between which cells are annota
 ![**Consensus cell type annotation gene expression in other diagnosis groups.**](https://raw.githubusercontent.com/AlexsLemonade/scpca-paper-figures/main/figures/compiled_figures/pngs/figure_s6.png?sanitize=true){#fig:figS6 tag="S6" width="9in"}
 
 Dot plots showing expression of cell-type-specific marker genes across all libraries from Leukemia (A), Sarcoma (B), and Other solid tumors (C).
-Expression is shown for each broad consensus cell type annotation.
-The y-axis displays the consensus cell type observed across libraries, with the total number of cells indicated in parentheses.
-The x-axis displays marker genes, determined by `CellMarker2.0` [@doi:10.1093/nar/gkac947], used for consensus cell type validation for each cell types shown along the top annotation bar.
-Dots are colored by mean gene expression across libraries and sized proportionally to the percent of libraries they are observed in, out of all cells in the given diagnosis.
+Expression is shown for each broad cell type annotation, where each broad cell type annotation is a collection of similar consensus cell type annotations.
+The y-axis displays the broad consensus cell type observed across libraries, with the total number of cells indicated in parentheses.
+The x-axis displays marker genes, determined by `CellMarker2.0` [@doi:10.1093/nar/gkac947], used for consensus cell type validation for each cell type shown along the top annotation bar.
+Dots are colored by mean gene expression across libraries and sized proportionally to the percent of libraries they are observed in, out of all cells with the same broad cell type annotation in the given diagnosis.
 <br><br>
 
 <!-- Figure S7 -->

--- a/content/100.figure-table-legends.md
+++ b/content/100.figure-table-legends.md
@@ -95,11 +95,11 @@ The heatmap shown is from library `SCPCL000498` [@doi:10.1016/j.devcel.2022.04.0
 <!-- Figure 5 -->
 ![**Consensus cell type annotations in Brain and CNS tumors.**](https://raw.githubusercontent.com/AlexsLemonade/scpca-paper-figures/main/figures/compiled_figures/pngs/figure_5.png?sanitize=true){#fig:fig5 tag="5" width="7in"}
 
-A. Dot plot of marker gene expression across broad consensus cell type annotation groups, specifically considering cells across libraries of brain and central nervous system (CNS) tumors.
-The total number of cells in each cell type annotation group across all included libraries is shown in parentheses along the y-axis.
-The x-axis displays marker genes for each cell type annotation group.
-The top annotation bar indicates which cell type expresses the given marker gene, as determined by CellMarker2.0.
-Dots are colored by mean gene expression across libraries and sized proportionally to the percent of libraries they are observed in.
+A. Dot plot showing expression of cell-type-specific marker genes across all libraries from brain and central nervous system (CNS) tumors.
+Expression is shown for each broad consensus cell type annotation.
+The y-axis displays the consensus cell type observed across libraries, with the total number of cells indicated in parentheses.
+The x-axis displays marker genes, determined by `CellMarker2.0` [@doi:10.1093/nar/gkac947], used for consensus cell type validation for each cell types shown along the top annotation bar.
+Dots are colored by mean gene expression across libraries and sized proportionally to the percent of libraries they are observed in, out of all cells in brain and CNS tumor libraries.
 
 B. Barplot showing the percentage of each broad consensus cell type annotation across libraries of brain and CNS tumors, separated into high-grade (left panel) and low-grade (right panel) glioma diagnoses.
 
@@ -246,10 +246,11 @@ A value of 1 means that there is complete overlap between which cells are annota
 <!-- Figure S6 -->
 ![**Consensus cell type annotation gene expression in other diagnosis groups.**](https://raw.githubusercontent.com/AlexsLemonade/scpca-paper-figures/main/figures/compiled_figures/pngs/figure_s6.png?sanitize=true){#fig:figS6 tag="S6" width="9in"}
 
-Dot plots showing expression of cell-type-specific marker genes across all libraries obtained from  Leukemia (A), Sarcoma (B), and Other solid tumors (C) for each broad consensus cell type annotation.
-In each panel, the total number of cells in each cell type annotation group across samples is shown in parentheses along the y-axis.
-The x-axis displays marker genes for each cell type annotation group.
-Dots are colored by mean gene expression across all ScPCA libraries and sized proportionally to the percent of libraries they are observed in.
+Dot plots showing expression of cell-type-specific marker genes across all libraries from Leukemia (A), Sarcoma (B), and Other solid tumors (C).
+Expression is shown for each broad consensus cell type annotation.
+The y-axis displays the consensus cell type observed across libraries, with the total number of cells indicated in parentheses.
+The x-axis displays marker genes, determined by `CellMarker2.0` [@doi:10.1093/nar/gkac947], used for consensus cell type validation for each cell types shown along the top annotation bar.
+Dots are colored by mean gene expression across libraries and sized proportionally to the percent of libraries they are observed in, out of all cells in the given diagnosis.
 <br><br>
 
 <!-- Figure S7 -->
@@ -257,7 +258,6 @@ Dots are colored by mean gene expression across all ScPCA libraries and sized pr
 
 Barplots of the percentage of cells annotated as each broad consensus cell type annotation across all libraries obtained from Leukemia (A), Sarcoma (B), and Other solid tumors (C).
 Within each panel, libraries are shown grouped by diagnosis.
-<br><br>
 <br><br>
 
 <!-- Figure S8 -->

--- a/content/100.figure-table-legends.md
+++ b/content/100.figure-table-legends.md
@@ -238,7 +238,7 @@ Dots are colored by mean gene expression across all ScPCA libraries and sized pr
 <br><br>
 
 <!-- Figure S7 -->
-![***Consensus cell type annotation distributions in other diagnosis groups.**](https://raw.githubusercontent.com/AlexsLemonade/scpca-paper-figures/v0.1.0/figures/compiled_figures/pngs/figure_s7.png?sanitize=true){#fig:figS7 tag="S7" width="7in"}
+![***Consensus cell type annotation distributions in other diagnosis groups.**](https://raw.githubusercontent.com/AlexsLemonade/scpca-paper-figures/main/figures/compiled_figures/pngs/figure_s7.png?sanitize=true){#fig:figS7 tag="S7" width="7in"}
 
 Panels A-C show barplots of the percentage of broad consensus cell type annotations, specifically considering libraries across ScPCA diagnosis groups Leukemia (A), Sarcoma (B) and Other solid tumors (C).
 Within each panel, libraries are shown grouped by diagnosis.

--- a/content/100.figure-table-legends.md
+++ b/content/100.figure-table-legends.md
@@ -96,15 +96,17 @@ The heatmap shown is from library `SCPCL000498` [@doi:10.1016/j.devcel.2022.04.0
 ![**Consensus cell type annotations in Brain and CNS tumors.**](https://raw.githubusercontent.com/AlexsLemonade/scpca-paper-figures/main/figures/compiled_figures/pngs/figure_5.png?sanitize=true){#fig:fig5 tag="5" width="7in"}
 
 A. Dot plot of marker gene expression across broad consensus cell type annotation groups, specifically considering cells across libraries of brain and central nervous system (CNS) tumors.
-In each panel, the total number of cells in each cell type annotation group across libraries considered is shown in parentheses along the y-axis.
-The x-axis displays marker genes for each cell type annotation group.
+The total number of cells in each cell type annotation group across all included libraries is shown in parentheses along the y-axis.
+The x-axis displays marker genes for each cell type annotation group. 
+The top annotation bar indicates which cell type expresses the given marker gene, as determined by CellMarker2.0. 
 Dots are colored by mean gene expression across libraries and sized proportionally to the percent of libraries they are observed in.
 
 B. Barplot showing the percentage of each broad consensus cell type annotation across libraries of brain and CNS tumors, separated into high-grade (left panel) and low-grade (right panel) glioma diagnoses.
 
-C. Barplot showing the percentages of different consensus cell type immune cells across libraries of brain and CNS tumors, separated into high-grade (left panel) and low-grade (right panel) glioma diagnoses.
+C. Barplot showing all consensus cell types classified as immune cells across libraries of brain and CNS tumors, separated into high-grade (left panel) and low-grade (right panel) glioma diagnoses.
+The percentage shown corresponds to the percentage of immune cells classified as the indicated consensus cell type.
 Only libraries comprised of at least 1\% immune cells, based on consensus cell type annotations, are shown.
-Specific consensus cell types for myeloid and leukocyte immune cells are shown, with all other consensus immune cell types included "other."
+Specific consensus cell types for myeloid and lymphocyte immune cells are shown, with all other consensus immune cell types included in "other."
 Notably, granulocytes are also included in "other" because only 1 granulocyte was present in all libraries shown (specifically, `SCPCL000793`).
 <br><br>
 
@@ -231,7 +233,7 @@ A value of 1 means that there is complete overlap between which cells are annota
 <!-- Figure S6 -->
 ![**Consensus cell type annotation gene expression in other diagnosis groups.**](https://raw.githubusercontent.com/AlexsLemonade/scpca-paper-figures/main/figures/compiled_figures/pngs/figure_s6.png?sanitize=true){#fig:figS6 tag="S6" width="9in"}
 
-Panels A-C show dot plots of marker gene expression across broad consensus cell type annotation groups, specifically considering cells across ScPCA diagnosis groups Leukemia (A), Sarcoma (B) and Other solid tumors (C).
+Dot plots showing expression of cell-type-specific marker genes across all libraries obtained from  Leukemia (A), Sarcoma (B), and Other solid tumors (C) for each broad consensus cell type annotation. 
 In each panel, the total number of cells in each cell type annotation group across samples is shown in parentheses along the y-axis.
 The x-axis displays marker genes for each cell type annotation group.
 Dots are colored by mean gene expression across all ScPCA libraries and sized proportionally to the percent of libraries they are observed in.
@@ -240,6 +242,6 @@ Dots are colored by mean gene expression across all ScPCA libraries and sized pr
 <!-- Figure S7 -->
 ![***Consensus cell type annotation distributions in other diagnosis groups.**](https://raw.githubusercontent.com/AlexsLemonade/scpca-paper-figures/main/figures/compiled_figures/pngs/figure_s7.png?sanitize=true){#fig:figS7 tag="S7" width="7in"}
 
-Panels A-C show barplots of the percentage of broad consensus cell type annotations, specifically considering libraries across ScPCA diagnosis groups Leukemia (A), Sarcoma (B) and Other solid tumors (C).
+Barplots of the percentage of cells annotated as each broad consensus cell type annotation across all libraries obtained from Leukemia (A), Sarcoma (B), and Other solid tumors (C).
 Within each panel, libraries are shown grouped by diagnosis.
 <br><br>

--- a/content/100.figure-table-legends.md
+++ b/content/100.figure-table-legends.md
@@ -236,3 +236,10 @@ In each panel, the total number of cells in each cell type annotation group acro
 The x-axis displays marker genes for each cell type annotation group.
 Dots are colored by mean gene expression across all ScPCA libraries and sized proportionally to the percent of libraries they are observed in.
 <br><br>
+
+<!-- Figure S7 -->
+![***Consensus cell type annotation distributions in other diagnosis groups.**](https://raw.githubusercontent.com/AlexsLemonade/scpca-paper-figures/v0.1.0/figures/compiled_figures/pngs/figure_s7.png?sanitize=true){#fig:figS7 tag="S7" width="7in"}
+
+Panels A-C show barplots of the percentage of broad consensus cell type annotations, specifically considering libraries across ScPCA diagnosis groups Leukemia (A), Sarcoma (B) and Other solid tumors (C).
+Within each panel, libraries are shown grouped by diagnosis.
+<br><br>

--- a/content/100.figure-table-legends.md
+++ b/content/100.figure-table-legends.md
@@ -90,6 +90,23 @@ B. Example heatmap as shown in the cell type summary report comparing annotation
 Heatmap cells are colored by the Jaccard similarity index.
 A value of 1 means that there is complete overlap between which cells are annotated with the two labels being compared, and a value of 0 means that there is no overlap between which cells are annotated with the two labels being compared.
 The heatmap shown is from library `SCPCL000498` [@doi:10.1016/j.devcel.2022.04.003].
+<br><br>
+
+<!-- Figure 5 -->
+![**Consensus cell type annotations in Brain and CNS tumors.**](https://raw.githubusercontent.com/AlexsLemonade/scpca-paper-figures/main/figures/compiled_figures/pngs/figure_5.png?sanitize=true){#fig:fig5 tag="5" width="7in"}
+
+A. Dot plot of marker gene expression across broad consensus cell type annotation groups, specifically considering cells across libraries of brain and central nervous system (CNS) tumors.
+In each panel, the total number of cells in each cell type annotation group across libraries considered is shown in parentheses along the y-axis.
+The x-axis displays marker genes for each cell type annotation group.
+Dots are colored by mean gene expression across libraries and sized proportionally to the percent of libraries they are observed in.
+
+B. Barplot showing the percentage of each broad consensus cell type annotation across libraries of brain and CNS tumors, separated into high-grade (left panel) and low-grade (right panel) glioma diagnoses.
+
+C. Barplot showing the percentages of different consensus cell type immune cells across libraries of brain and CNS tumors, separated into high-grade (left panel) and low-grade (right panel) glioma diagnoses.
+Only libraries comprised of at least 1\% immune cells, based on consensus cell type annotations, are shown.
+Specific consensus cell types for myeloid and leukocyte immune cells are shown, with all other consensus immune cell types included "other."
+Notably, granulocytes are also included in "other" because only 1 granulocyte was present in all libraries shown (specifically, `SCPCL000793`).
+<br><br>
 
 ## Supplementary Figures and Tables {.page_break_before}
 
@@ -200,7 +217,7 @@ Red diamonds represent the median delta median score for all cells with high-qua
 <!--Figure S5-->
 ![**Cell type annotation with `CellAssign`.**](https://raw.githubusercontent.com/AlexsLemonade/scpca-paper-figures/main/figures/compiled_figures/pngs/figure_s5.png?sanitize=true){#fig:figS5 tag="S5" height="10in"}
 
-Both plots in this figure are examples of plots that display results from annotating cells with `CellAssign` that can be found in the cell type summary report, shown here for library `SCPCL000498` [@doi:10.1016/j.devcel.2022.04.003]. 
+Both plots in this figure are examples of plots that display results from annotating cells with `CellAssign` that can be found in the cell type summary report, shown here for library `SCPCL000498` [@doi:10.1016/j.devcel.2022.04.003].
 
 A. A grid of UMAPs is shown for each cell type annotated using `CellAssign`, with the cell type of interest shown in color and all other cells belonging to other cell types shown in gray.
 The top four cell types with the greatest number of assigned cells are shown, while all other cells are grouped together and labeled with `All remaining cell types`.

--- a/content/100.figure-table-legends.md
+++ b/content/100.figure-table-legends.md
@@ -227,3 +227,12 @@ B. This example heatmap from the cell type summary report compares submitter-pro
 This heatmap is only shown in the cell type summary report if submitters provided cell type annotations.
 Heatmap cells are colored by the Jaccard similarity index.
 A value of 1 means that there is complete overlap between which cells are annotated with the two labels being compared, and a value of 0 means that there is no overlap between which cells are annotated with the two labels being compared.
+
+<!-- Figure S6 -->
+![**Consensus cell type annotation gene expression in other diagnosis groups.**](https://raw.githubusercontent.com/AlexsLemonade/scpca-paper-figures/main/figures/compiled_figures/pngs/figure_s6.png?sanitize=true){#fig:figS6 tag="S6" width="9in"}
+
+Panels A-C show dot plots of marker gene expression across broad consensus cell type annotation groups, specifically considering cells across ScPCA diagnosis groups Leukemia (A), Sarcoma (B) and Other solid tumors (C).
+In each panel, the total number of cells in each cell type annotation group across samples is shown in parentheses along the y-axis.
+The x-axis displays marker genes for each cell type annotation group.
+Dots are colored by mean gene expression across all ScPCA libraries and sized proportionally to the percent of libraries they are observed in.
+<br><br>

--- a/content/100.figure-table-legends.md
+++ b/content/100.figure-table-legends.md
@@ -96,7 +96,7 @@ The heatmap shown is from library `SCPCL000498` [@doi:10.1016/j.devcel.2022.04.0
 ![**Consensus cell type annotations in Brain and CNS tumors.**](https://raw.githubusercontent.com/AlexsLemonade/scpca-paper-figures/main/figures/compiled_figures/pngs/figure_5.png?sanitize=true){#fig:fig5 tag="5" width="7in"}
 
 A. Dot plot showing expression of cell-type-specific marker genes across all libraries from brain and central nervous system (CNS) tumors.
-Expression is shown for each broad cell type annotation, where each broad cell type annotation is a collection of similar consensus cell type annotations. 
+Expression is shown for each broad cell type annotation, where each broad cell type annotation is a collection of similar consensus cell type annotations.
 The y-axis displays the broad consensus cell type observed across libraries, with the total number of cells indicated in parentheses.
 The x-axis displays marker genes, determined by `CellMarker2.0` [@doi:10.1093/nar/gkac947], used for consensus cell type validation for each cell type shown along the top annotation bar.
 Dots are colored by mean gene expression across libraries and sized proportionally to the percent of libraries they are observed in, out of all cells with the same broad cell type annotation in brain and CNS tumor libraries.
@@ -246,7 +246,7 @@ A value of 1 means that there is complete overlap between which cells are annota
 <!-- Figure S6 -->
 ![**Consensus cell type annotation gene expression in other diagnosis groups.**](https://raw.githubusercontent.com/AlexsLemonade/scpca-paper-figures/main/figures/compiled_figures/pngs/figure_s6.png?sanitize=true){#fig:figS6 tag="S6" width="9in"}
 
-Dot plots showing expression of cell-type-specific marker genes across all libraries from Leukemia (A), Sarcoma (B), and Other solid tumors (C).
+Dot plots showing expression of cell-type-specific marker genes across all libraries from Leukemia (A), Sarcoma (B), and Other solid tumors (C) diagnosis groups.
 Expression is shown for each broad cell type annotation, where each broad cell type annotation is a collection of similar consensus cell type annotations.
 The y-axis displays the broad consensus cell type observed across libraries, with the total number of cells indicated in parentheses.
 The x-axis displays marker genes, determined by `CellMarker2.0` [@doi:10.1093/nar/gkac947], used for consensus cell type validation for each cell type shown along the top annotation bar.
@@ -256,7 +256,7 @@ Dots are colored by mean gene expression across libraries and sized proportional
 <!-- Figure S7 -->
 ![***Consensus cell type annotation distributions in other diagnosis groups.**](https://raw.githubusercontent.com/AlexsLemonade/scpca-paper-figures/main/figures/compiled_figures/pngs/figure_s7.png?sanitize=true){#fig:figS7 tag="S7" width="7in"}
 
-Barplots of the percentage of cells annotated as each broad consensus cell type annotation across all libraries obtained from Leukemia (A), Sarcoma (B), and Other solid tumors (C).
+Barplots of the percentage of cells annotated as each broad consensus cell type annotation across all libraries from Leukemia (A), Sarcoma (B), and Other solid tumors (C) diagnosis groups.
 Within each panel, libraries are shown grouped by diagnosis.
 <br><br>
 


### PR DESCRIPTION
Closes #140 (not 143, as branch name says, that is a typo...)
Stacked on #150 

This PR adds legends for Figures 5, S6, and S7.  These figures are interrelated, so much of the text is similar. For now, I'm linking to the PNGs in `main`, but this will be updated once we get to #149.