### PR TITLE
Clarify no multiplexed in fig 5

### DIFF
--- a/content/100.figure-table-legends.md
+++ b/content/100.figure-table-legends.md
@@ -95,7 +95,7 @@ The heatmap shown is from library `SCPCL000498` [@doi:10.1016/j.devcel.2022.04.0
 <!-- Figure 5 -->
 ![**Consensus cell type annotations in Brain and CNS tumors.**](https://raw.githubusercontent.com/AlexsLemonade/scpca-paper-figures/main/figures/compiled_figures/pngs/figure_5.png?sanitize=true){#fig:fig5 tag="5" width="7in"}
 
-A. Dot plot showing expression of cell-type-specific marker genes across all libraries from brain and central nervous system (CNS) tumors.
+A. Dot plot showing expression of cell-type-specific marker genes across all libraries from brain and central nervous system (CNS) tumors, excluding any multiplexed libraries.
 Expression is shown for each broad cell type annotation, where each broad cell type annotation is a collection of similar consensus cell type annotations.
 The y-axis displays the broad consensus cell type observed across libraries, with the total number of cells indicated in parentheses.
 The x-axis displays marker genes, determined by `CellMarker2.0` [@doi:10.1093/nar/gkac947], used for consensus cell type validation for each cell type shown along the top annotation bar.

--- a/content/100.figure-table-legends.md
+++ b/content/100.figure-table-legends.md
@@ -95,15 +95,15 @@ The heatmap shown is from library `SCPCL000498` [@doi:10.1016/j.devcel.2022.04.0
 <!-- Figure 5 -->
 ![**Consensus cell type annotations in Brain and CNS tumors.**](https://raw.githubusercontent.com/AlexsLemonade/scpca-paper-figures/main/figures/compiled_figures/pngs/figure_5.png?sanitize=true){#fig:fig5 tag="5" width="7in"}
 
-A. Dot plot showing expression of cell-type-specific marker genes across all libraries from brain and central nervous system (CNS) tumors, excluding any multiplexed libraries.
+A. Dot plot showing expression of cell-type-specific marker genes across all libraries from brain and central nervous system (CNS) tumors, excluding multiplexed libraries.
 Expression is shown for each broad cell type annotation, where each broad cell type annotation is a collection of similar consensus cell type annotations.
 The y-axis displays the broad consensus cell type observed across libraries, with the total number of cells indicated in parentheses.
 The x-axis displays marker genes, determined by `CellMarker2.0` [@doi:10.1093/nar/gkac947], used for consensus cell type validation for each cell type shown along the top annotation bar.
 Dots are colored by mean gene expression across libraries and sized proportionally to the percent of libraries they are observed in, out of all cells with the same broad cell type annotation in brain and CNS tumor libraries.
 
-B. Barplot showing the percentage of each broad consensus cell type annotation across libraries of brain and CNS tumors, separated into high-grade (left panel) and low-grade (right panel) glioma diagnoses.
+B. Barplot showing the percentage of each broad consensus cell type annotation across libraries of brain and CNS tumors, separated into high-grade (left panel) and low-grade (right panel) glioma diagnoses for non-multiplexed libraries.
 
-C. Barplot showing all consensus cell types classified as immune cells across libraries of brain and CNS tumors, separated into high-grade (left panel) and low-grade (right panel) glioma diagnoses.
+C. Barplot showing all consensus cell types classified as immune cells across libraries of brain and CNS tumors, separated into high-grade (left panel) and low-grade (right panel) glioma diagnoses for non-multiplexed libraries.
 The percentage shown corresponds to the percentage of immune cells classified as the indicated consensus cell type.
 Only libraries comprised of at least 1\% immune cells, based on consensus cell type annotations, are shown.
 Specific consensus cell types for myeloid and lymphocyte immune cells are shown, with all other consensus immune cell types included in "other."


### PR DESCRIPTION
Closes #155 

This PR adds some phrasing to the Fig 5 legend that multiplexed libraries are not shown (should we actually say multiplexed _samples_ aren't shown? e.g., "excluding libraries for multiplexed samples"?_. Since SCPCP0000009 is the only multiplexed project, I only added to this figure's legend since it's the only consensus figure with brain.

Let me know if this phrasing is ok!