### PR TITLE
Add Avrohom to author list

### DIFF
--- a/content/metadata.yaml
+++ b/content/metadata.yaml
@@ -128,6 +128,21 @@ authors:
       - Childhood Cancer Data Lab, Alex's Lemonade Stand Foundation, Bala Cynwyd, PA, 19004, USA
     funders:
       - Alex's Lemonade Stand Foundation Childhood Cancer Data Lab (CCDL)
+  - github: avrohomgottlieb
+    name: Avrohom M. Gottlieb
+    initials: AMG
+    email: avrohom@ccdatalab.org
+    contributions:
+      - Methodology
+      - Software
+      - Validation
+      - Data curation
+      - Writing - Review & Editing
+      - Resources
+    affiliations:
+      - Childhood Cancer Data Lab, Alex's Lemonade Stand Foundation, Bala Cynwyd, PA, 19004, USA
+    funders:
+      - Alex's Lemonade Stand Foundation Childhood Cancer Data Lab (CCDL)
   - github: kurtwheeler
     name: Kurt G. Wheeler
     initials: KGW


### PR DESCRIPTION
Closes #156 

I added Avrohom to the author list after Ark but before Kurt? Let me know if we should use a different order. I confirmed the name/ middle initial with him and no ORCID id. For contributions, I used the same that we had for Ark and David, which I think should be correct. 