### PR TITLE
Make abstract shorter

### DIFF
--- a/content/01.abstract.md
+++ b/content/01.abstract.md
@@ -3,7 +3,7 @@
 The Single-cell Pediatric Cancer Atlas (ScPCA) Portal (<https://scpca.alexslemonade.org/>) is a data resource for uniformly processed single-cell and single-nuclei RNA sequencing (RNA-seq) data and de-identified metadata from pediatric tumor samples.
 Originally comprised of data from 10 projects funded by Alex’s Lemonade Stand Foundation, the Portal currently contains summarized gene expression data for over 700 samples across 55 cancer types from ALSF-funded and community-contributed datasets.
 Downloads include gene expression data as `SingleCellExperiment` or `AnnData` objects containing raw and normalized counts, PCA and UMAP coordinates, and automated cell type annotations, along with summary reports.
-Some samples have additonal data from bulk RNA-seq, spatial transcriptomics, and/or feature barcoding (e.g., CITE-seq and cell hashing) included in the download.
+Some samples have additional data from bulk RNA-seq, spatial transcriptomics, and/or feature barcoding (e.g., CITE-seq and cell hashing) included in the download.
 Merged objects containing all gene expression data and metadata for all samples in an ScPCA project are also available.
 All data on the Portal were uniformly processed using `scpca-nf`, an open-source and efficient Nextflow workflow that uses `alevin-fry` to quantify gene expression.
 Comprehensive documentation, including descriptions of file contents and a guide to getting started, is available at <http://scpca.readthedocs.io>. 

--- a/content/01.abstract.md
+++ b/content/01.abstract.md
@@ -1,9 +1,8 @@
 ## Abstract {.page_break_before}
 
 The Single-cell Pediatric Cancer Atlas (ScPCA) Portal (<https://scpca.alexslemonade.org/>) is a data resource for uniformly processed single-cell and single-nuclei RNA sequencing (RNA-seq) data and de-identified metadata from pediatric tumor samples.
-Originally comprised of data from 10 projects funded by Alex’s Lemonade Stand Foundation, the Portal currently contains summarized gene expression data for over 700 samples across 55 cancer types from ALSF-funded and community-contributed datasets.
+Originally comprised of data from 10 projects funded by Alex’s Lemonade Stand Foundation (ALSF), the Portal currently contains summarized gene expression data for over 700 samples across 55 cancer types from ALSF-funded and community-contributed datasets.
 Downloads include gene expression data as `SingleCellExperiment` or `AnnData` objects containing raw and normalized counts, PCA and UMAP coordinates, and automated cell type annotations, along with summary reports.
 Some samples have additional data from bulk RNA-seq, spatial transcriptomics, and/or feature barcoding (e.g., CITE-seq and cell hashing) included in the download.
-Merged objects containing all gene expression data and metadata for all samples in an ScPCA project are also available.
 All data on the Portal were uniformly processed using `scpca-nf`, an open-source and efficient Nextflow workflow that uses `alevin-fry` to quantify gene expression.
 Comprehensive documentation, including descriptions of file contents and a guide to getting started, is available at <http://scpca.readthedocs.io>. 

--- a/content/01.abstract.md
+++ b/content/01.abstract.md
@@ -1,15 +1,9 @@
 ## Abstract {.page_break_before}
 
 The Single-cell Pediatric Cancer Atlas (ScPCA) Portal (<https://scpca.alexslemonade.org/>) is a data resource for uniformly processed single-cell and single-nuclei RNA sequencing (RNA-seq) data and de-identified metadata from pediatric tumor samples.
-Originally comprised of data from 10 projects funded by Alex’s Lemonade Stand Foundation, the Portal currently contains summarized gene expression data for 700 samples from 55 types of cancers from ALSF-funded and community-contributed datasets.
-In addition to gene expression data from single-cell and single-nuclei RNA-seq, the Portal holds data obtained from bulk RNA-seq, spatial transcriptomics, and feature barcoding methods, such as CITE-seq and cell hashing.
-
-ScPCA data are available for download as `SingleCellExperiment` or `AnnData` objects and are ready for downstream analyses.
-Objects include raw counts and normalized gene expression data, PCA and UMAP coordinates, and automated cell type annotations.
-Additionally, all downloads include two summary reports for each library: a quality control report summarizing sample statistics and displaying visualizations of cell metrics and a cell type annotation report with comparisons among cell type annotation methods and diagnostic plots to assess annotation quality.
-Merged `SingleCellExperiment` and `AnnData` objects containing all gene expression data and metadata for all samples in an ScPCA project are also available for download.
-These objects are useful when performing analysis on multiple samples simultaneously.
-Comprehensive documentation about data processing and the contents of files on the Portal, including a guide to getting started working with an ScPCA dataset, can be found at <http://scpca.readthedocs.io>.
-
-All data on the Portal were uniformly processed using `scpca-nf`, an open-source and efficient Nextflow workflow that uses `alevin-fry` to quantify all single-cell and single-nuclei RNA-seq data, any associated CITE-seq or cell hash data, spatial transcriptomics data, and bulk RNA-seq.
-Any pediatric cancer-relevant data sets processed with `scpca-nf` are eligible for inclusion on the ScPCA Portal, enabling continuous growth of the ScPCA Portal to help pediatric cancer researchers spend less time finding and processing data and more time answering their pressing research questions.
+Originally comprised of data from 10 projects funded by Alex’s Lemonade Stand Foundation, the Portal currently contains summarized gene expression data for over 700 samples across 55 cancer types from ALSF-funded and community-contributed datasets.
+Downloads include gene expression data as `SingleCellExperiment` or `AnnData` objects containing raw and normalized counts, PCA and UMAP coordinates, and automated cell type annotations, along with summary reports.
+Some samples have additonal data from bulk RNA-seq, spatial transcriptomics, and/or feature barcoding (e.g., CITE-seq and cell hashing) included in the download.
+Merged objects containing all gene expression data and metadata for all samples in an ScPCA project are also available.
+All data on the Portal were uniformly processed using `scpca-nf`, an open-source and efficient Nextflow workflow that uses `alevin-fry` to quantify gene expression.
+Comprehensive documentation, including descriptions of file contents and a guide to getting started, is available at <http://scpca.readthedocs.io>. 


### PR DESCRIPTION
Closes #168 

Here I'm making the abstract much shorter and more succinct. The version I have right now is 172 words so it's pretty close... I pared it down to keep the main points and got rid of a lot of detail. I think the biggest thing that got taken away is a description of what's included in the reports and the sentence noting that any dataset processed with `scpca-nf` is eligible for inclusion. We do have a very similar statement about eligible datasets in the introduction, so I thought it would be fine to remove.  