### PR TITLE
Move information into methods/cut from results re: workflow description

### DIFF
--- a/content/03.results.md
+++ b/content/03.results.md
@@ -43,11 +43,10 @@ Nextflow will also handle parallelizing sample processing as allowed by the envi
 The combination of being able to execute a Nextflow workflow in any environment and run individual processes in Docker containers makes this workflow easily portable for external use.
 
 When building `scpca-nf`, we sought a fast and memory-efficient tool for gene expression quantification to minimize processing costs.
-We expected many users of the Portal to have their own single-cell or single-nuclei data processed with Cell Ranger [@doi:10.1038/ncomms14049; @url:https://www.10xgenomics.com/support/software/cell-ranger/latest], due to its popularity.
+Due to its popularity, we expected many users of the Portal to process their own single-cell or single-nuclei data with Cell Ranger [@doi:10.1038/ncomms14049; @url:https://www.10xgenomics.com/support/software/cell-ranger/latest].
 Thus, selecting a tool with comparable results to Cell Ranger was also desirable.
 In comparing `alevin-fry` [@doi:10.1038/s41592-022-01408-3] to Cell Ranger, we found `alevin-fry` had a lower run time and memory usage (Figure {@fig:figS1}A), while retaining comparable mean gene expression for all genes (Figure {@fig:figS1}B), total UMIs per cell (Figure {@fig:figS1}C), and total genes detected per cell (Figure {@fig:figS1}D).
-(All analyses comparing gene expression quantification tools are available in a public analysis repository: <https://github.com/AlexsLemonade/alsf-scpca>.)
-Based on these results, we elected to use `salmon alevin` and `alevin-fry` [@doi:10.1038/s41592-022-01408-3] in `scpca-nf` to quantify gene expression data.
+Based on these results, we used `salmon alevin` and `alevin-fry` [@doi:10.1038/s41592-022-01408-3] in `scpca-nf` to quantify gene expression data.
 
 Taking FASTQ files as input, `scpca-nf` aligns reads using the selective alignment option in `salmon alevin` to an index with transcripts corresponding to spliced cDNA and intronic regions, denoted by `alevin-fry` as a `splici` index (Figure {@fig:fig2}A).
 The output from `alevin-fry` includes a gene-by-cell count matrix for all barcodes identified, even those that may not contain true cells.
@@ -56,7 +55,7 @@ The output from `alevin-fry` includes a gene-by-cell count matrix for all barcod
 The unfiltered gene-by-cell counts matrices are filtered to remove any barcodes that are not likely to contain cells using `DropletUtils::emptyDropsCellRanger()`[@doi:10.1186/s13059-019-1662-y].
 Low-quality cells are identified and removed with `miQC` [@doi:10.1371/journal.pcbi.1009290], which jointly models the proportion of mitochondrial reads and detected genes per cell and calculates a probability that each cell is compromised.
 The remaining cells' counts are normalized [@doi:10.1186/s13059-016-0947-7], and reduced-dimension representations are calculated using both principal component analysis (PCA) and uniform manifold approximation and projection (UMAP) [@arxiv:1802.03426].
-Finally, cell types are classified using two automated methods, `SingleR` [@doi:10.1038/s41590-018-0276-y] and `CellAssign` [@doi:10.1038/s41592-019-0529-1], and an ontology-aware consensus cell type is derived from these automated labels where possible.
+Finally, cell types are classified using two automated methods, `SingleR` [@doi:10.1038/s41590-018-0276-y] and `CellAssign` [@doi:10.1038/s41592-019-0529-1].
 
 To make downloading from the Portal convenient for R and Python users, downloads are available as either `SingleCellExperiment` or `AnnData`[@doi:10.1101/2021.12.16.473007] objects.
 The workflow outputs a `SingleCellExperiment` object (saved as an `.rds` file) containing the fully processed results, including the dimension reduction results and cell type annotations, as well as objects containing the unfiltered and the empty droplet filtered gene-by-cell matrices.
@@ -76,36 +75,21 @@ A UMAP plot with cells colored by the total number of genes detected and a facet
 ### Antibody-derived tags
 
 To process ADT libraries, the ADT FASTQ files are quantified using `salmon alevin` and `alevin-fry` (Figure {@fig:figS2}A).
-Along with the FASTQ files, `scpca-nf` takes a tab-separated values (TSV) file with one row for each ADT – containing the name used for the ADT and associated barcode – required to build an ADT-specific index for quantifying ADT expression with `alevin-fry`.
 The output from `alevin-fry` is the unfiltered ADT-by-cell counts matrix.
 The ADT-by-cell counts matrix is read into R alongside the gene-by-cell counts matrix and saved as an alternative experiment (`altExp`) within the main `SingleCellExperiment` object containing the unfiltered RNA counts.
-
-Any cells removed after filtering empty droplets based on the unfiltered RNA counts matrix are also removed from the ADT counts matrix.
-`scpca-nf` does not filter any cells based on ADT expression or remove cells with low-quality ADT expression.
-Instead, the workflow calculates QC statistics for ADT counts using `DropletUtils::cleanTagCounts()` and stores them alongside the ADT-by-cell counts matrix in the filtered `SingleCellExperiment` object.
-Users can use these statistics to filter based on ADT counts before proceeding to downstream analyses if they choose.
-
-The ADT-by-cell counts matrix is normalized first by determining the ambient profile and then using that profile to calculate median size factors with `scuttle::computeMedianFactors()` [@doi:10.18129/B9.bioc.scuttle; @url:https://bioconductor.org/books/3.16/OSCA.advanced/integrating-with-protein-abundance.html#cite-seq-median-norm].
-We skip normalization for cells with low-quality ADT expression, as indicated by `DropletUtils::cleanTagCounts()`.
-Although `scpca-nf` normalizes ADT counts, the workflow does not perform any dimensionality reduction of ADT data; only the RNA counts data are used as input for dimensionality reduction.
-The normalized ADT data are saved as an `altExp` within the processed `SingleCellExperiment` containing the normalized RNA data.
-During conversion to `AnnData` objects, the modalities are exported as separate RNA (`_rna.h5ad`) and ADT (`_adt.h5ad`) objects.
+No filtering based on ADT expression or quality is performed; instead, we report QC statistics that users can employ for filtering before performing downstream analyses.
+The workflow also performs ADT-by-cell counts matrix normalization (see Methods for details).
 
 If a library contains ADT data, the QC report will include an additional section with a summary of ADT-related statistics, such as how many cells express each ADT, and ADT-specific diagnostic plots (Figure {@fig:figS2}B-D).
-As mentioned above, `scpca-nf` uses `DropletUtils::cleanTagCounts()` to calculate QC statistics for each cell using ADT expression but does not filter any cells from the object.
 We include plots summarizing the potential effects of removing low-quality cells based on RNA and ADT counts in the QC report (Figure {@fig:figS2}B).
-The first quadrant indicates which cells would be kept if the object was filtered using both RNA and ADT quality measures.
-The other facets highlight which cells would be removed if filtering was done using only RNA counts, only ADT counts, or both.
+The first quadrant indicates which cells would be kept if the object were filtered using both RNA and ADT quality measures.
+The other facets highlight which cells would be removed if filtering were done using only RNA counts, only ADT counts, or both.
 The top four ADTs with the most variable expression are also identified and visualized using density plots to show the normalized ADT expression across all cells (Figure {@fig:figS2}C) and UMAPs – calculated from RNA expression data – with cells colored by ADT expression (Figure {@fig:figS2}D).
 
 ### Multiplexed libraries
 
 To process multiplexed libraries, the HTO FASTQ files are quantified using `salmon alevin` and `alevin-fry` (Figure {@fig:figS2}C).
-Along with the FASTQ files, `scpca-nf` requires two TSV files to process multiplexed data: one to build an HTO-specific index for quantifying HTO expression with `alevin-fry`, and a second to indicate which HTO was used for which sample when multiplexing the library.
-The unfiltered HTO-by-cell counts matrix output from `alevin-fry` is saved as an `altExp` within the main `SingleCellExperiment` containing the unfiltered RNA counts.
-
-As with ADT data, `scpca-nf` does not filter any cells based on HTO expression, and any cells removed after filtering empty droplets based on the unfiltered RNA counts matrix are also removed from the HTO counts matrix in the filtered object.
-`scpca-nf` does not perform any additional filtering or processing of the HTO-by-cell counts matrix, so the same filtered matrix is included in the processed object.
+The unfiltered HTO-by-cell counts matrix output from `alevin-fry` is saved as an `altExp` within the main `SingleCellExperiment`, containing the unfiltered RNA counts.
 
 Although `scpca-nf` quantifies the HTO data and includes an HTO-by-cell counts matrix in all objects, `scpca-nf` does not demultiplex the samples into one sample per library.
 Instead, `scpca-nf` applies multiple demultiplexing methods, including demultiplexing with `DropletUtils::hashedDrops()` [@doi:10.18129/B9.bioc.DropletUtils], demultiplexing with `Seurat::HTODemux()` [@doi:10.1186/s13059-018-1603-1], and genetic demultiplexing when bulk RNA-seq data are available.
@@ -121,8 +105,7 @@ No additional plots are produced, but a table summarizing the results from all t
 Some samples also include data from bulk RNA-seq and/or spatial transcriptomics libraries.
 Both of these additional sequencing methods are supported by `scpca-nf`.
 To quantify bulk RNA-seq data, `scpca-nf` takes bulk FASTQ files as input, trims reads using `fastp` [@doi:10.1093/bioinformatics/bty560], and then aligns and quantifies reads with `salmon` (Figure {@fig:figS3}A) [@doi:10.1038/nmeth.4197].
-The output is a single TSV file with the gene-by-sample counts matrix for all samples in a given ScPCA project.
-This gene-by-sample matrix is only included with project downloads on the Portal.
+The output is a single TSV file with the gene-by-sample counts matrix for all samples in a given ScPCA project, which is only included with project downloads on the Portal.
 
 To quantify spatial transcriptomics data, `scpca-nf` takes the RNA FASTQ and slide image as input (Figure {@fig:figS3}B).
 As `alevin-fry` does not yet fully support spatial transcriptomics data, `scpca-nf` uses Space Ranger to quantify all spatial transcriptomics data [@url:https://www.10xgenomics.com/support/software/space-ranger/latest].
@@ -130,11 +113,6 @@ The output includes the spot-by-gene matrix along with a summary report produced
 
 ## Downloading projects from the ScPCA Portal
 
-<!-- TODO:
-⚠️ JNT thinks this level of repetition of facts covered in earlier sections is good.
-See what you think during your review.
-JAS: I think it is fine,but I also think it could easily be cut if needed for length.
--->
 On the Portal, users can either download data from individual samples or all data from an entire ScPCA project.
 When downloading data for an entire project, users can choose between receiving the individual files for each sample (default) or one file containing the gene expression data and metadata for all samples in the project as a merged object.
 Users also have the option to choose their desired format and receive the data as `SingleCellExperiment` (`.rds`) or `AnnData` (`.h5ad`) objects.
@@ -149,26 +127,17 @@ If the ScPCA project includes samples with bulk RNA-seq, two additional files ar
 ### Merged objects
 
 Providing data for all samples within a single file facilitates performing joint gene-level analyses, such as differential expression or gene set enrichment analyses, on multiple samples simultaneously.
-Therefore, we provide a single, merged object for each project containing all raw and normalized gene expression data and metadata for all single-cell and single-nuclei RNA-seq libraries within a given ScPCA project.
-We provide merged objects for all projects in the Portal except for those with multiplexing, due to potential ambiguity in identifying samples across multiplexed libraries.
-No further processing besides merging the object is performed; batch-correction is not performed, and integrated data is not provided.
+Therefore, we provide a single, merged object for each project containing all raw and normalized gene expression data and metadata for all single-cell and single-nuclei RNA-seq libraries within a given ScPCA project (with some exceptions fully described in the Methods).
 If downloading data from an ScPCA project as a single, merged file, the download will include a single `.rds` or `.h5ad` file, a summary report for the merged object, and a folder with all individual QC and cell type reports for each library found in the merged object (Figure {@fig:fig3}B).
 
 To build the merged objects, we created an additional stand-alone workflow for merging the output from `scpca-nf`, `merge.nf` (Figure {@fig:fig3}C).
-`merge.nf` takes as input the processed `SingleCellExperiment` objects output by `scpca-nf` for all single-cell and single-nuclei libraries included in a given ScPCA project.
-The gene expression data stored in all `SingleCellExperiment` objects are then merged to produce a single merged gene-by-cell counts matrix containing all cells from all libraries.
-No batch correction is performed when creating the merged object.
+`merge.nf` takes the processed `SingleCellExperiment` objects for all single-cell and single-nuclei libraries in a given ScPCA project as input and produces a single merged gene-by-cell counts matrix containing all cells from all libraries.
+No batch correction or integration is performed when creating the merged object.
 Where possible, library-, cell- and gene-specific metadata found in the individual processed `SingleCellExperiment` objects are also merged.
 The merged normalized counts matrix is then used to select high-variance genes in a library-aware manner before performing dimensionality reduction with both PCA and UMAP.
 `merge.nf` outputs the merged and processed object as a `SingleCellExperiment` object.
-The more samples that are included in a merged object, the larger the object, and the more difficult it is to work with that object in R or Python.
-Therefore, we do not provide merged objects for projects with more than 100 samples.
-
-We also account for additional modalities in `merge.nf`.
-If at least one library in a project contains ADT data, the raw and normalized ADT data are also merged and saved as an `altExp` in the merged `SingleCellExperiment` object.
-If any libraries in a project are multiplexed, no merged object is created, as there is no guarantee that a unique HTO was used for each sample in a given project.
 All merged `SingleCellExperiment` objects are converted to `AnnData` objects and exported as `.h5ad` files.
-If the merged object contains an `altExp` with merged ADT data, two `AnnData` objects are exported to create separate RNA (`_rna.h5ad`) and ADT (`_adt.h5ad`) objects.
+We also account for additional modalities in `merge.nf` (see Methods).
 
 `merge.nf` outputs a summary report for each merged object, which includes a set of tables summarizing the types of samples and libraries included in the project, such as types of diagnosis, and a faceted UMAP showing all cells from all libraries.
 Figure {@fig:fig3}D shows an example of this plot with a subset of libraries from an ScPCA project.

--- a/content/03.results.md
+++ b/content/03.results.md
@@ -77,8 +77,8 @@ A UMAP plot with cells colored by the total number of genes detected and a facet
 To process ADT libraries, the ADT FASTQ files are quantified using `salmon alevin` and `alevin-fry` (Figure {@fig:figS2}A).
 The output from `alevin-fry` is the unfiltered ADT-by-cell counts matrix.
 The ADT-by-cell counts matrix is read into R alongside the gene-by-cell counts matrix and saved as an alternative experiment (`altExp`) within the main `SingleCellExperiment` object containing the unfiltered RNA counts.
-No filtering based on ADT expression or quality is performed; instead, we report QC statistics that users can employ for filtering before performing downstream analyses.
-The workflow also performs ADT-by-cell counts matrix normalization (see Methods for details).
+The workflow performs ADT-by-cell counts matrix normalization (see Methods for details), but no filtering based on ADT expression or quality is performed.
+Instead, we report QC statistics that users can employ for additional filtering before performing downstream analyses.
 
 If a library contains ADT data, the QC report will include an additional section with a summary of ADT-related statistics, such as how many cells express each ADT, and ADT-specific diagnostic plots (Figure {@fig:figS2}B-D).
 We include plots summarizing the potential effects of removing low-quality cells based on RNA and ADT counts in the QC report (Figure {@fig:figS2}B).
@@ -89,7 +89,7 @@ The top four ADTs with the most variable expression are also identified and visu
 ### Multiplexed libraries
 
 To process multiplexed libraries, the HTO FASTQ files are quantified using `salmon alevin` and `alevin-fry` (Figure {@fig:figS2}C).
-The unfiltered HTO-by-cell counts matrix output from `alevin-fry` is saved as an `altExp` within the main `SingleCellExperiment`, containing the unfiltered RNA counts.
+As with ADT data, the HTO-by-cell counts matrix produced by `alevin-fry` is saved as an `altExp` within the main `SingleCellExperiment` object.
 
 Although `scpca-nf` quantifies the HTO data and includes an HTO-by-cell counts matrix in all objects, `scpca-nf` does not demultiplex the samples into one sample per library.
 Instead, `scpca-nf` applies multiple demultiplexing methods, including demultiplexing with `DropletUtils::hashedDrops()` [@doi:10.18129/B9.bioc.DropletUtils], demultiplexing with `Seurat::HTODemux()` [@doi:10.1186/s13059-018-1603-1], and genetic demultiplexing when bulk RNA-seq data are available.
@@ -105,7 +105,7 @@ No additional plots are produced, but a table summarizing the results from all t
 Some samples also include data from bulk RNA-seq and/or spatial transcriptomics libraries.
 Both of these additional sequencing methods are supported by `scpca-nf`.
 To quantify bulk RNA-seq data, `scpca-nf` takes bulk FASTQ files as input, trims reads using `fastp` [@doi:10.1093/bioinformatics/bty560], and then aligns and quantifies reads with `salmon` (Figure {@fig:figS3}A) [@doi:10.1038/nmeth.4197].
-The output is a single TSV file with the gene-by-sample counts matrix for all samples in a given ScPCA project, which is only included with project downloads on the Portal.
+The output is a single TSV file with the gene-by-sample counts matrix for all samples in a given ScPCA project.
 
 To quantify spatial transcriptomics data, `scpca-nf` takes the RNA FASTQ and slide image as input (Figure {@fig:figS3}B).
 As `alevin-fry` does not yet fully support spatial transcriptomics data, `scpca-nf` uses Space Ranger to quantify all spatial transcriptomics data [@url:https://www.10xgenomics.com/support/software/space-ranger/latest].
@@ -127,7 +127,7 @@ If the ScPCA project includes samples with bulk RNA-seq, two additional files ar
 ### Merged objects
 
 Providing data for all samples within a single file facilitates performing joint gene-level analyses, such as differential expression or gene set enrichment analyses, on multiple samples simultaneously.
-Therefore, we provide a single, merged object for each project containing all raw and normalized gene expression data and metadata for all single-cell and single-nuclei RNA-seq libraries within a given ScPCA project (with some exceptions fully described in the Methods).
+Therefore, we provide a single, merged object for each project containing all raw and normalized gene expression data and metadata for all single-cell and single-nuclei RNA-seq libraries within a given ScPCA project (with some exceptions as described in the Methods).
 If downloading data from an ScPCA project as a single, merged file, the download will include a single `.rds` or `.h5ad` file, a summary report for the merged object, and a folder with all individual QC and cell type reports for each library found in the merged object (Figure {@fig:fig3}B).
 
 To build the merged objects, we created an additional stand-alone workflow for merging the output from `scpca-nf`, `merge.nf` (Figure {@fig:fig3}C).
@@ -135,9 +135,9 @@ To build the merged objects, we created an additional stand-alone workflow for m
 No batch correction or integration is performed when creating the merged object.
 Where possible, library-, cell- and gene-specific metadata found in the individual processed `SingleCellExperiment` objects are also merged.
 The merged normalized counts matrix is then used to select high-variance genes in a library-aware manner before performing dimensionality reduction with both PCA and UMAP.
+If additional modalities are present, these are similarly merged and included in the output object (see Methods).
 `merge.nf` outputs the merged and processed object as a `SingleCellExperiment` object.
 All merged `SingleCellExperiment` objects are converted to `AnnData` objects and exported as `.h5ad` files.
-We also account for additional modalities in `merge.nf` (see Methods).
 
 `merge.nf` outputs a summary report for each merged object, which includes a set of tables summarizing the types of samples and libraries included in the project, such as types of diagnosis, and a faceted UMAP showing all cells from all libraries.
 Figure {@fig:fig3}D shows an example of this plot with a subset of libraries from an ScPCA project.

--- a/content/04.methods.md
+++ b/content/04.methods.md
@@ -48,7 +48,7 @@ The resulting `SingleCellExperiment` contains a `counts` assay with a gene-by-ce
 We also include a `spliced` assay that contains a gene-by-cell counts matrix with only spliced reads.
 These matrices include all potential cells, including empty droplets, and are provided for all Portal downloads in the unfiltered objects saved as `.rds` files with the `_unfiltered.rds` suffix.
 
-Each droplet was tested for deviation from the ambient RNA profile using `DropletUtils::emptyDropsCellRanger()` [@doi:10.1186/s13059-019-1662-y] and those with an FDR ≤ 0.01 were retained as likely cells.
+Each droplet was tested for deviation from the ambient RNA profile using `DropletUtils::emptyDropsCellRanger()` [@doi:10.1186/s13059-019-1662-y; @doi:10.1101/2021.05.05.442755] and those with an FDR ≤ 0.01 were retained as likely cells.
 If a library did not have a sufficient number of droplets and `DropletUtils::emptyDropsCellRanger()` failed, cells with fewer than 100 UMIs were removed.
 Gene expression data for any cells that remain after filtering are provided in the filtered objects saved as `.rds` files with the `_filtered.rds` suffix.
 

--- a/content/04.methods.md
+++ b/content/04.methods.md
@@ -48,7 +48,7 @@ The resulting `SingleCellExperiment` contains a `counts` assay with a gene-by-ce
 We also include a `spliced` assay that contains a gene-by-cell counts matrix with only spliced reads.
 These matrices include all potential cells, including empty droplets, and are provided for all Portal downloads in the unfiltered objects saved as `.rds` files with the `_unfiltered.rds` suffix.
 
-Each droplet was tested for deviation from the ambient RNA profile using `DropletUtils::emptyDropsCellRanger()` and those with an FDR ≤ 0.01 were retained as likely cells.
+Each droplet was tested for deviation from the ambient RNA profile using `DropletUtils::emptyDropsCellRanger()` [@doi:10.1186/s13059-019-1662-y] and those with an FDR ≤ 0.01 were retained as likely cells.
 If a library did not have a sufficient number of droplets and `DropletUtils::emptyDropsCellRanger()` failed, cells with fewer than 100 UMIs were removed.
 Gene expression data for any cells that remain after filtering are provided in the filtered objects saved as `.rds` files with the `_filtered.rds` suffix.
 
@@ -84,8 +84,14 @@ ADT count data were then normalized by calculating median size factors using the
 If median-based normalization failed for any reason, ADT counts were log-transformed after adding a pseudocount of 1.
 Normalized counts are only available for any cells that would be retained after ADT filtering, and any cells that would be filtered out based on `DropletUtils::cleanTagCounts()` are assigned `NA`.
 The normalized ADT data are available in the `altExp` of the processed object.
+Although `scpca-nf` normalizes ADT counts, the workflow does not perform any dimensionality reduction of ADT data; only the RNA counts data are used as input for dimensionality reduction.
+
+During conversion to `AnnData` objects, the modalities are exported as separate RNA (`_rna.h5ad`) and ADT (`_adt.h5ad`) objects.
 
 ### Processing HTO data from multiplexed libraries
+
+As with ADT data, `scpca-nf` does not filter any cells based on HTO expression, and any cells removed after filtering empty droplets based on the unfiltered RNA counts matrix are also removed from the HTO counts matrix in the filtered object.
+`scpca-nf` does not perform any additional filtering or processing of the HTO-by-cell counts matrix, so the same filtered matrix is included in the processed object.
 
 To identify which cells come from which sample in a multiplexed library, we applied three different demultiplexing methods: genetic demultiplexing, HTO demultiplexing using `DropletUtils::hashedDrops()`, and HTO demultiplexing using `Seurat::HTODemux()`.
 We do not provide separate `SingleCellExperiment` objects for each sample in a library.
@@ -169,15 +175,17 @@ This workflow takes as input the processed `SingleCellExperiment` objects in a g
 The merged object includes both raw and normalized counts for all cells from all libraries.
 Because the same reference index was used to quantify all single-cell and single-nuclei RNA-seq data, the set of genes is the same in the merged object and the individual objects.
 Library-, cell- and gene-specific metadata from each of the processed `SingleCellExperiment` objects are also combined and stored in the merged object.
-The `merge.nf` workflow does not perform batch correction or integration, so the counts in the merged object not batch-corrected.
+The `merge.nf` workflow does not perform batch correction or integration, so the counts in the merged object are not batch-corrected.
 
 The top 2000 shared high-variance genes are identified from the merged counts matrix by modeling variance using `scran::modelGeneVar()` and specifying library IDs for the `block` argument.
 These genes are used to calculate library-aware principal components with `batchelor::multiBatchPCA()` [@doi:10.1038/nbt.4091].
 The top 50 principal components were selected and used to calculate UMAP embeddings for the merged object.
 
-If any libraries included in the ScPCA project contain additional ADT data, the ADT data are also merged and stored in the `altExp` slot of the merged `SingleCellExperiment` object.
-By contrast, if any libraries included in the ScPCA project are multiplexed and contain HTO data, no merged object is created.
-Merged objects were not created for projects with more than 100 samples because of the computational resources that would be required for working with those objects.
+If any libraries included in the ScPCA project contain additional ADT data, the raw and normalized ADT data are also merged and stored in the `altExp` slot of the merged `SingleCellExperiment` object.
+If the merged object contains an `altExp` with merged ADT data, two `AnnData` objects are exported to create separate RNA (`_rna.h5ad`) and ADT (`_adt.h5ad`) objects.
+
+If any libraries in the ScPCA project are multiplexed and contain HTO data, no merged object is created due to potential ambiguity in identifying samples across multiplexed libraries.
+Merged objects were not created for projects with more than 100 samples because of the computational resources required to work with them.
 
 ### Converting SingleCellExperiment objects to AnnData objects
 


### PR DESCRIPTION
Towards my part of #160 

I am starting with this pull request that cuts from the workflow description in the results section (up to cell annotation) and moves things to the methods as appropriate. 

I stopped here so we can go through it carefully and make sure we're still capturing everything we need to convey in one of these two sections.