### PR TITLE
Add some more details about benchmarking

### DIFF
--- a/content/100.figure-table-legends.md
+++ b/content/100.figure-table-legends.md
@@ -158,7 +158,11 @@ The reference includes marker genes for all cell types present in each organ.
 <!-- Figure S1 -->
 ![**Results from benchmarking `alevin-fry` and `CellRanger` performance.**](https://raw.githubusercontent.com/AlexsLemonade/scpca-paper-figures/v0.1.1/figures/compiled_figures/pngs/figure_s1.png?sanitize=true){#fig:figS1 tag="S1" width="7in"}
 
-Each panel compares metrics for six representative ScPCA libraries, including three single-cell and three single-nuclei suspensions, obtained from processing libraries with both `alevin-fry` and `CellRanger`.
+Each panel compares metrics for six representative ScPCA libraries, including three single-cell and three single-nuclei suspensions, obtained from processing libraries with `salmon alevin` and `alevin-fry` or `CellRanger`.
+Results shown were generated with `CellRanger v6.1.2` using default parameters for single-cell libraries and use of the `--include_introns` flag to include intronic reads for single-nuclei libraries. 
+All libraries were processed with `salmon alevin v1.5.2` and `alevin-fry v0.4.1` using an index containing both spliced and unspliced cDNA as mentioned in the Methods. 
+The libraries used for benchmarking were randomly chosen. 
+
 
 A. Runtime in minutes (top row) and peak memory in GB (bottom row) for six ScPCA libraries processed with `alevin-fry` and `CellRanger`.
 Processing with `alevin-fry` was consistently faster and more memory-efficient compared to processing with `CellRanger`.

--- a/content/100.figure-table-legends.md
+++ b/content/100.figure-table-legends.md
@@ -158,7 +158,7 @@ The reference includes marker genes for all cell types present in each organ.
 <!-- Figure S1 -->
 ![**Results from benchmarking `alevin-fry` and `CellRanger` performance.**](https://raw.githubusercontent.com/AlexsLemonade/scpca-paper-figures/v0.1.1/figures/compiled_figures/pngs/figure_s1.png?sanitize=true){#fig:figS1 tag="S1" width="7in"}
 
-Each panel compares metrics for six representative ScPCA libraries, including three single-cell and three single-nuclei suspensions, obtained from processing libraries with `salmon alevin` and `alevin-fry` or `CellRanger`.
+Each panel compares metrics for six ScPCA libraries, including three single-cell and three single-nuclei suspensions, obtained from processing libraries with `salmon alevin` and `alevin-fry` or `CellRanger`.
 Results shown were generated with `CellRanger v6.1.2` using default parameters for single-cell libraries and use of the `--include_introns` flag to include intronic reads for single-nuclei libraries. 
 All libraries were processed with `salmon alevin v1.5.2` and `alevin-fry v0.4.1` using an index containing both spliced and unspliced cDNA as mentioned in the Methods. 
 The libraries used for benchmarking were randomly chosen. 


### PR DESCRIPTION
Closes #189 

To address the comments about benchmarking I added some more details to the figure legend to note what versions of Cell Ranger and `alevin-fry` were used. I also noted that we ran it with the `--include_introns` flag for only single-nuclei samples. 

I also added a note that the libraries were randomly chosen. 

I think having this in the figure legend makes the most sense, but if you think it belongs somewhere else let me know. 

I updated the R2R response to include a response to this point as well: 
https://docs.google.com/document/d/1KxIxSUwL7y5gnYiMP4HhsgVvi5JZKHMiAQNo70xT4gU/edit?tab=t.0