### PR TITLE
Clarify normalization and add doublet text

### DIFF
--- a/content/04.methods.md
+++ b/content/04.methods.md
@@ -66,7 +66,10 @@ Following removal of empty droplets, `scpca-nf` proceeds to remove cells that ar
 `miQC` was used to calculate the posterior probability that each cell is compromised [@doi:10.1371/journal.pcbi.1009290].
 Any cells with a probability of being compromised greater than 0.75 and fewer than 200 genes detected were removed before further processing.
 The gene expression counts from the remaining cells were log-normalized using the deconvolution method from Lun, Bach, and Marioni [@doi:10.1186/s13059-016-0947-7].
-`scran::modelGeneVar()` was used to model gene variance from the log-normalized counts and `scran::getTopHVGs()` was used to select the top 2000 high-variance genes.
+Briefly, `scran::quickCluster()` was used to derive cell clusters on which to calculate sum factors with `scran::computeSumFactors()`, which are in turn used during normalization with `scuttle::logNormCounts()`.
+If this deconvolution-based approach failed for any reason, only `scuttle::logNormCounts()` was used for normalization.
+
+Next, `scran::modelGeneVar()` was used to model gene variance from the log-normalized counts and `scran::getTopHVGs()` was used to select the top 2000 high-variance genes.
 These were used as input to calculate the top 50 principal components using `scater::runPCA()`.
 Finally, UMAP embeddings were calculated from the principal components with `scater::runUMAP()`.
 The raw and log-normalized counts, list of 2000 high-variance genes, principal components, and UMAP embeddings are all stored in the processed objects saved as `.rds` files with the `_processed.rds` suffix.


### PR DESCRIPTION
Closes #187 
Closes #188 

This PR tackles two small paper updates:

- For #187, I expanded our description of the specific procedure used for normalization to give the literal functions used instead of only stating the conceptual approach
- For #188, I added new text about doublet detection
- I also did a couple other language updates which seemed helpful here for textual flow of the whole processing pipeline.