### PR TITLE
Expand ADT section

### DIFF
--- a/content/04.methods.md
+++ b/content/04.methods.md
@@ -90,8 +90,8 @@ Any cells removed after filtering empty droplets were also removed from the ADT 
 The ADT count matrix stored in the unfiltered object was used to calculate an ambient profile with `DropletUtils::ambientProfileEmpty()`.
 The ambient profile was used to calculate quality-control statistics with `DropletUtils::cleanTagCounts()` for all cells remaining after removing empty droplets.
 Any negative or isotype controls were taken into account when calculating QC statistics.
-This function flags cells as low-quality if they either have very high levels of ambient contamination and/or negative/isotype controls (if present), or lack ambient expression altogether which may indicate failed capture.
-However, we did not remove any cells based on ADT quality because that would remove those cells from the `SingleCellExperiment` object altogether regardless of the quality of the RNA expression.
+This function flags cells as low-quality if they either have very high levels of ambient contamination and/or negative/isotype controls (if present), or lack ambient expression altogether, which may indicate failed capture.
+However, we did not remove any cells based on ADT quality because that would remove those cells from the `SingleCellExperiment` object, regardless of the quality of the RNA expression.
 Instead, the filtered and processed objects contain the results from running `DropletUtils::cleanTagCounts()`, which users can leverage for filtering as desired.
 
 ADT count data were then normalized using `scuttle::computeMedianFactors()`, which calculates a per-cell size factor as the median ratio of the cell's counts to the background profile previously calculated with `DropletUtils::ambientProfileEmpty()`.


### PR DESCRIPTION
Closes #186 

This PR generally expands our discussion of ADT processing to ensure we're clearly laying out the processing steps. For this, I added some more details about normalization and included a statement that we don't subtract out the background but you can do it if you want, maybe using the global ambient profile we provide. 

While I was here, I noticed that the details for the filtering were also _slightly_ off - the `discard` flag from that filtering function flags cells with excessively low expression as well as high, so I added in that language. (Note we need a docs issue to fix this there too; I'm on it!) I also clarified a smidge the text about how we don't _perform_ filtering to state that users can do this themselves.

Let me know if you think any wording should be tweaked!