### PR TITLE
Account for scimilarity in cell typing methods

### DIFF
--- a/build/assets/custom-dictionary.txt
+++ b/build/assets/custom-dictionary.txt
@@ -174,6 +174,7 @@ Wilms
 xenograft
 xenografts
 Yakovets
+Zenodo
 AGH
 JAS
 SJS

--- a/content/04.methods.md
+++ b/content/04.methods.md
@@ -162,7 +162,7 @@ Given the processed `SingleCellExperiment` object and organ-specific reference, 
 For each cell, `CellAssign` calculates a probability of assignment to each cell type in the reference.
 The probability matrix and a prediction based on the most probable cell type were added as cell type annotations to the processed `SingleCellExperiment` object.
 
-For `SCimilarity`, the foundation model described in Heimberg et al. [@doi:10.1038/s41586-024-08411-y] containing 7.3 million cells from various normal and diseased tissues was obtained from zenodo (<https://zenodo.org/records/10685499>) and used to annotate cells in all samples.
+For `SCimilarity`, the foundation model described in Heimberg et al. [@doi:10.1038/s41586-024-08411-y] containing 7.3 million cells from various normal and diseased tissues was obtained from Zenodo (<https://zenodo.org/records/10685499>) and used to annotate cells in all samples.
 The assigned cell type label and the distance of the query cell to the closest cell in the model were added to the processed `SingleCellExperiment` object.
 
 #### Assigning consensus cell types
@@ -172,7 +172,7 @@ We first assigned each of the cell types present in the `PanglaoDB` [@doi:10.109
 For cell types available in the `BlueprintEncodeData` reference used with `SingleR` and the foundation model used with `SCimilarity`, we used the provided Cell Ontology terms.
 
 We then created a reference table containing all possible combinations of cell types assigned using `SingleR`, `CellAssign`, and `SCimilarity`. 
-Consensus cell types are assigned if two of the three annotations share a latest common ancestor (LCA), identified using `ontoProc::findCommonAncestors()` [@doi:10.18129/B9.bioc.ontoProc], that meets the following critera. 
+Consensus cell types are assigned if two of the three annotations share a latest common ancestor (LCA), identified using `ontoProc::findCommonAncestors()` [@doi:10.18129/B9.bioc.ontoProc], that meets the following criteria. 
 Otherwise, no consensus cell type is assigned, and the cell is labeled as "Unknown".
 
 1. The terms share at least 1 LCA that either has fewer than 170 descendants or is one of `neuron`, `epithelial cell`, `columnar/cuboidal epithelial cell` or `endo-epithelial cell`.


### PR DESCRIPTION
Closes #198 

Here I'm updating the cell typing section to include `SCimilarity` and then updating the consensus cell type section to account for that addition. There wasn't a lot to mention there other than we use the model on Zenodo to run it. 

For the updates to consensus, I included some of the same description that we have in `scpca-docs`. Let me know if I should expand on anything else there? 