### PR TITLE
Shuffle existing figure legends, part 1

### DIFF
--- a/content/100.figure-table-legends.md
+++ b/content/100.figure-table-legends.md
@@ -56,7 +56,7 @@ In the actual summary QC report, the top 12 most highly variable genes are shown
 H. File download structure for an ScPCA Portal project download in `SingleCellExperiment` (`SCE`) format.
 The download folder is named according to the project ID, data format, and the date it was downloaded.
 Download folders contain a folder for all single-cell data, `_single-cell`.
-This folder contains  for each sample ID, each containing the three versions (unfiltered, filtered, and processed) of the expression data as well as the summary QC report and cell type report all named according to the ScPCA library ID.
+This folder contains a folder for each sample ID, each containing the three versions (unfiltered, filtered, and processed) of the expression data as well as the summary QC report and cell type report all named according to the ScPCA library ID.
 The `single-cell_metadata.tsv` file contains sample metadata for all samples included in the download.
 The `README.md` file provides information about the contents of each download file, additional contact and citation information, and terms of use for data downloaded from the ScPCA Portal.
 The folder `_bulk` is only present for projects that also have bulk RNA-Seq data.
@@ -64,8 +64,8 @@ It contains a gene-by-sample matrix of raw gene expression as quantified by `sal
 
 I. File download structure for an ScPCA Portal merged project download in `SCE` format.
 The download folder is named according to the project ID, data format, and the date it was downloaded.
-Download folders contain a folder for all single-cell data, `_single-cell`.
-This folder contains a single merged object containing all samples in the given project, a summary report briefly detailing the contents of the merged object.
+Download folders contain a folder for all single-cell data, `_single-cell_merged`.
+This folder contains a single merged object containing all samples in the given project and a summary report briefly detailing the contents of the merged object.
 All summary QC and cell type reports for each individual library are also provided in the `individual_reports` folder arranged by their sample ID.
 As in panel (H), additional files `single-cell_metadata.tsv`, `_bulk_quant.tsv`, `_bulk_metadata.tsv`, and `README.md` are also included.
 <br><br>


### PR DESCRIPTION
Towards #224 

This PR begins the figure legend updates. Changes here include (edit: this is the first 5 bullets of #224):

- Remove the previous S5 legend 
- Rename S6 -> S5, S7 -> S6, S8 -> S7
- Move the previous 3A --> 2H, and update text to match the updated download image: https://github.com/AlexsLemonade/scpca-paper-figures/blob/main/figures/svgs/Fig2H_sc-project-download-folder.svg. I moved the 4A legend to now be 3A, as described in #224. 4A now contains a TODO, forthcoming in the next PR.
- Move the previous 3B --> 2I, and update text to match the updated download image: https://github.com/AlexsLemonade/scpca-paper-figures/blob/main/figures/svgs/Fig2I_merged-sc-project-download-folder.svg. I left a TODO in 3B to tackle soon.



Note that I did not attempt to make any changes outside of the figure legend file, e.g. update results content to match these changes since I thought that would be too much to do at once and we should leave it for #216. Let me know if you want to see any such changes here though. 