### PR TITLE
Shuffle figure legends part 2

### DIFF
--- a/content/100.figure-table-legends.md
+++ b/content/100.figure-table-legends.md
@@ -109,7 +109,7 @@ D. <TODO>: https://github.com/AlexsLemonade/ScPCA-manuscript/issues/223
 <br><br>
 
 <!-- Figure 5 -->
-<TODO>: https://github.com/AlexsLemonade/ScPCA-manuscript/issues/220
+<<!-- TODO: Write this legend. https://github.com/AlexsLemonade/ScPCA-manuscript/issues/220 -->
 
 <!-- Figure 6 -->
 ![**Comparison of bulk and pseudobulk modalities.**](https://raw.githubusercontent.com/AlexsLemonade/scpca-paper-figures/v0.1.1/figures/compiled_figures/pngs/figure_6.png?sanitize=true){#fig:fig6 tag="6" width="7in"}
@@ -234,6 +234,7 @@ For this figure specifically, the merged UMAP was constructed from a merged obje
 <br><br>
 
 <!--Figure S4-->
+<!-- TODO: Rewrite this legend. https://github.com/AlexsLemonade/ScPCA-manuscript/issues/221 -->
 ![**Evaluation of references available in the celldex package for use with SingleR.**](https://raw.githubusercontent.com/AlexsLemonade/scpca-paper-figures/v0.1.1/figures/compiled_figures/pngs/figure_s4.png?sanitize=true){#fig:figS4 tag="S4" width="7in"}
 
 `SingleR` was used to annotate ScPCA libraries using four different human-specific references from the `celldex` package.


### PR DESCRIPTION
Closes #224 
This PR wraps up shuffling of existing legends:

- 3C --> S3C. TODO left behind
- 3D --> S3D. Nothing left behind, there's no more 3D.
- Move Fig 4 to be Fig 5, leaving 2 TODOs behind:
  - a TODO for the 4D legend
  - a TODO for the full figure 5 legend 
  - Note I added a sentence here (this is the only text change) that we cap genes at 10 per group. How's this wording?
- I also left a TODO for updating the S4 legend 