### PR TITLE
Update legends for panels 3B & 3C

### DIFF
--- a/content/100.figure-table-legends.md
+++ b/content/100.figure-table-legends.md
@@ -84,7 +84,7 @@ Although not shown in this panel, cell type annotations are also included in the
 B. Diagram of ontology-aware consensus cell type annotation performed in `scpca-nf`.
 We perform pairwise comparisons among cell type annotations made by `SingleR`, `CellAssign`, and `SCimilarity`.
 For each comparison, we identify the cell types' latest common ancestor based on the Cell Ontology. 
-We then identify the consensus cell type as the latest common ancestor with the fewest descendents. 
+We then identify the consensus cell type as the latest common ancestor with the fewest descendants. 
 
 C. Example heatmap as shown in the cell type summary report comparing the consensus cell type annotations to automated annotations assigned by `SingleR`, `CellAssign`, and `SCimilarity`. 
 Heatmap cells are colored by the Jaccard similarity index. 


### PR DESCRIPTION
Closes #222 
Stacked on #227

This PR adds the legends for 3B (consensus diagram) and 3C (cell type heatmap). In particular, let me know how the phrasing looks for 3B - how's this for a general overview of the approach? Should I add any of the finer details, or add more phrasing to indicate that there are more finer details?

For 3C, I poached a lot of the phrasing from existing/previous legends:
https://github.com/AlexsLemonade/ScPCA-manuscript/blob/7c03c9dd714909b0b7078f1712f7c6a6b306e4ef/content/100.figure-table-legends.md?plain=1#L95-L96
https://github.com/AlexsLemonade/ScPCA-manuscript/blob/8a40219a1153d7ffbb0ba09b649e3b69c028e2da/content/100.figure-table-legends.md?plain=1#L94