### PR TITLE
Add Figure 5 legend

### DIFF
--- a/content/100.figure-table-legends.md
+++ b/content/100.figure-table-legends.md
@@ -132,7 +132,7 @@ The UMAP was constructed from the merged `SCPCP000004` object such that all libr
 The total per-cell CNV values were calculated by summing the total number of chromosome arms with a CNV event, as estimated by the `i6` HMM in `InferCNV`.
 Gray cells are from libraries excluded from `InferCNV` inference because they did not contain enough normal cells to define the `InferCNV` reference baseline.
 
-C. Heatmap displaying per-cell CNV events across chromosomes with canonical neuroblastoma alterations [@doi:10.1038/nrdp.2016.78; 10.1016/j.celrep.2024.114804; 10.1158/2159-8290.CD-14-0622] for a single library, `SCPCL000130`.
+C. Heatmap displaying per-cell CNV events across chromosomes with canonical neuroblastoma alterations [@doi:10.1038/nrdp.2016.78; @doi:10.1016/j.celrep.2024.114804; @doi:10.1158/2159-8290.CD-14-0622] for a single library, `SCPCL000130`.
 Each cell in `SCPCL000130` is represented by two adjacent rows, the first indicating the presence or absence of a gain and the second indicating the presence or absence of a loss.  
 The heatmap is grouped by chromosome arm and OpenScPCA Project cell type annotation, where "normal" cells comprise all characterized non-malignant cells.
 This library exhibits strong signatures of canonical neuroblastoma alterations including `1p` loss, `11q` loss, and `17q` gain. 


### PR DESCRIPTION
Closes #220 

This PR adds the new figure 5 legend. For reference: https://raw.githubusercontent.com/AlexsLemonade/scpca-paper-figures/main/figures/compiled_figures/pngs/figure_5.png?sanitize=true

Let me know where I can clarify/rephrase! Note that at first I did explicitly state in the last 2 captions that CNV events were inferred with InferCNV but ended up removing it since it seemed redundant and not necessary - let me know if you disagree!