### PR TITLE
Add Fig S4 legend

### DIFF
--- a/content/100.figure-table-legends.md
+++ b/content/100.figure-table-legends.md
@@ -266,12 +266,12 @@ For this figure specifically, the merged UMAP was constructed from a merged obje
 <!--Figure S4-->
 ![**Ontology-aware consensus cell type assignment provides harmonized labels for cells.**](https://raw.githubusercontent.com/AlexsLemonade/scpca-paper-figures/main/figures/compiled_figures/pngs/figure_s4.png?sanitize=true){#fig:figS4 tag="S4" width="7in"}
 
-A. UMAP highlighting cells annotated as types of T cells with SingleR, CellAssign, SCimilarity as well as the associated consensus cell types for the library `SCPCL000049`.
+A. UMAP highlighting cells annotated as types of T cells with `SingleR`, `CellAssign`, `SCimilarity` as well as the associated consensus cell types for the library `SCPCL000049`.
 All other cells are shown in gray. 
 This UMAP specifically shows the top three T cell types for each cell type assignment, with remaining T cell types grouped together as "Other T cells."
 
 B. UMAP showing the top seven consensus cell types in `SCPCL0000049`.
-Aall additional consensus cell types are included in the "All remaining cell types" category.
+All additional consensus cell types are included in the "All remaining cell types" category.
 
 C. UMAP showing total per-cell CNV events for `SCPCL0000049`.
 The total per-cell CNV values were calculated by summing the total number of chromosome arms with a CNV event, as estimated by the `i6` HMM in `InferCNV` [@url:https://github.com/broadinstitute/inferCNV].


### PR DESCRIPTION
Stacked on #229 
Closes #221 

This PR adds the Fig S4 legend. Here is the figure for reference: https://raw.githubusercontent.com/AlexsLemonade/scpca-paper-figures/main/figures/compiled_figures/pngs/figure_s4.png?sanitize=true

I wonder if I'm a little thin on details for panel A? Let me know!
Please also feel free to suggest a title 😄 

----

Also, I realize we have a discrepancy to resolve here before we release `scpca-paper-figures`. 
In the README in that repo, I indicated this has a panel C: https://github.com/AlexsLemonade/scpca-paper-figures/blob/1bd1294548fa97eb02fa861b6355b0b9853d7ea9/README.md?plain=1#L87-L91
But as you'll note in the compiled figure, what I called B & C is actually just B!
One of those spots will need to be updated, and continued here accordingly. I have a slight preference for adding `C.` to the compilation and having three panels, but it's not a strong preference. Do you or @jaclyn-taroni have a strong preference? 