### PR TITLE
Add alpha-beta T cell to the list of cell types without marker genes

### DIFF
--- a/content/100.figure-table-legends.md
+++ b/content/100.figure-table-legends.md
@@ -121,7 +121,7 @@ The x-axis displays marker genes, determined by `CellMarker 2.0` [@doi:10.1093/n
 Dots are colored by mean gene expression across libraries and sized proportionally to the percent of libraries they are observed in, out of all cells with the same consensus cell type annotation in brain and CNS tumor libraries.
 A maximum of 10 cell type marker genes are shown for each consensus cell type annotation.
 Only broad cell type annotations that appear in at least 50 cells across samples in the given diagnosis group are shown.
-Cell types without associated marker genes in `CellMarker 2.0` are not shown, including `lymphocyte of B lineage`, `mature T cell`, `mature alpha-beta T cell`, `myeloid leukocyte`, and `tissue-resident macrophage`.
+Cell types without associated marker genes in `CellMarker 2.0` are not shown, including `lymphocyte of B lineage`, `mature T cell`, `mature alpha-beta T cell`, `alpha-beta T cell`, `myeloid leukocyte`, and `tissue-resident macrophage`.
 <br><br>
 
 <!-- Figure 5 -->


### PR DESCRIPTION
Related to https://github.com/AlexsLemonade/scpca-paper-figures/pull/395, this PR adds `alpha-beta T cell` to the list of excluded cell types for Figure 4D.