### PR TITLE
Update percentages of NB cells classified

### DIFF
--- a/content/03.results.md
+++ b/content/03.results.md
@@ -179,7 +179,7 @@ In parallel to developing the ScPCA Portal, we launched the OpenScPCA project [@
 Thus far, we have added cell type annotations for two projects, `SCPCP000004` (neuroblastoma) and `SCPCP000015` (Ewing sarcoma), to the Portal based on OpenScPCA analyses.
 Figure {@fig:fig5}A displays, for example, a UMAP of all libraries in `SCPCP000004` highlighting this project's OpenScPCA annotations, which were derived using the `NBAtlas` dataset as a reference [@doi:10.1016/j.celrep.2024.114804].
 Unlike the consensus cell type annotations, the OpenScPCA annotations distinguish between normal and malignant cells and contain far fewer uncharacterized cells.
-Indeed, for `SCPCP000004`, the consensus cell type procedure labeled only ~43% of cells, but the OpenScPCA project labeled ~91% of cells, more than doubling the number of labeled cells.
+For example, for `SCPCP000004`, the consensus cell type procedure labeled ~80% of cells, but the OpenScPCA project labeled ~88% of cells.
 When OpenScPCA annotations are available, the Portal's summary cell type report also includes comparisons between the `scpca-nf` and OpenScPCA annotations.
 
 In an effort to identify potential malignant cells across all samples in the Portal, `scpca-nf` applies `InferCNV` [@url:https://github.com/broadinstitute/inferCNV] to estimate copy-number alterations (Figure {@fig:fig2}A) when enough normal cells are present in a library to serve as a reference (see Methods for details).


### PR DESCRIPTION
Related to https://github.com/AlexsLemonade/scpca-paper-figures/pull/407

This PR updates the sentence where we report the percentage of cells classified in consensus vs openscpca for SCPCP000004. I removed the "indeed" and replaced with "for example" because this difference is somewhat less striking, but I think it's still noteworthy!