### PR TITLE
Initiate STAR methods and add experimental model section

### DIFF
--- a/content/04.methods.md
+++ b/content/04.methods.md
@@ -6,7 +6,7 @@
 
 Data on the ScPCA Portal were generated and compiled by each contributing lab and institution.
 As of May 1, 2026, gene expression data from 704 samples are available. 
-This includes 585 human patient samples, 117 samples from patient-derived xenografts, 4 samples from immortalized human cell lines, and 2 samples from cell lines passaged from patient-derived xenografts representing 55 different pediatric cancer types.
+This includes 581 human patient samples, 117 samples from patient-derived xenografts, 4 samples from immortalized human cell lines, and 2 samples from cell lines passaged from patient-derived xenografts representing 55 different pediatric cancer types.
 
 #### Metadata 
 

--- a/content/04.methods.md
+++ b/content/04.methods.md
@@ -1,15 +1,14 @@
-## Methods
+## STAR Methods
 
-### Data generation and processing
+### RESOURCE AVAILABILITY
 
-Raw data and metadata were generated and compiled by each lab and institution contributing to the Portal.
-Single-cell or single-nuclei libraries were generated using one of the commercially available kits from 10x Genomics.
-For bulk RNA-seq, RNA was collected and sequenced using either paired-end or single-end sequencing.
-For spatial transcriptomics, cDNA libraries were generated using the Visium kit from 10x Genomics.
-All libraries were processed using our open-source pipeline, `scpca-nf`, to produce summarized gene expression data.
-A detailed summary with the total number of samples and libraries collected for each sequencing method broken down by project is available in Table S1.
+### EXPERIMENTAL MODEL AND SUBJECT DETAILS
 
-### Metadata
+Data on the ScPCA Portal was generated and compiled by each contributing lab and institution.
+As of May 1, 2026, gene expression data from 700 total samples is available. 
+This includes 694 patient samples representing 55 different pediatric cancer types and 6 samples from human cell lines. 
+
+#### Metadata 
 
 Submitters were required to submit the age, sex, organism, diagnosis, subdiagnosis (if applicable), disease timing (e.g., initial diagnosis) and tissue of origin for each sample.
 The submitted metadata was standardized across projects, including converting all ages to years, removing abbreviations used in diagnosis, subdiagnosis, or tissue of origin, and using standard values across projects as much as possible for diagnosis, subdiagnosis, disease timing, and tissue of origin.
@@ -36,6 +35,19 @@ The majority (87%) of projects on the Portal have additional metadata fields, su
 For ALSF-funded datasets comprised of human subjects data, Institutional Review Boards (IRB) or research ethics boards at grantee institutions approved the research or determined it was exempt.
 For community-contributed datasets containing summarized data and de-identified metadata from human subjects, submitting institutions certified that all approvals and consents were obtained or listed the IRB protocol in transfer agreements.
 ALSF-funded xenograft datasets were approved by the grantee institution's Institutional Animal Care and Use Committee.
+
+
+### METHOD DETAILS
+
+### Data generation and processing
+
+Raw data and metadata were generated and compiled by each lab and institution contributing to the Portal.
+Single-cell or single-nuclei libraries were generated using one of the commercially available kits from 10x Genomics.
+For bulk RNA-seq, RNA was collected and sequenced using either paired-end or single-end sequencing.
+For spatial transcriptomics, cDNA libraries were generated using the Visium kit from 10x Genomics.
+All libraries were processed using our open-source pipeline, `scpca-nf`, to produce summarized gene expression data.
+A detailed summary with the total number of samples and libraries collected for each sequencing method broken down by project is available in Table S1.
+
 
 ### Processing single-cell and single-nuclei RNA-seq data with alevin-fry
 

--- a/content/04.methods.md
+++ b/content/04.methods.md
@@ -4,8 +4,8 @@
 
 ### EXPERIMENTAL MODEL AND SUBJECT DETAILS
 
-Data on the ScPCA Portal was generated and compiled by each contributing lab and institution.
-As of May 1, 2026, gene expression data from 700 samples is available. 
+Data on the ScPCA Portal were generated and compiled by each contributing lab and institution.
+As of May 1, 2026, gene expression data from 700 samples are available. 
 This includes 694 patient samples representing 55 different pediatric cancer types and 6 samples from human cell lines. 
 
 #### Metadata 

--- a/content/04.methods.md
+++ b/content/04.methods.md
@@ -5,7 +5,7 @@
 ### EXPERIMENTAL MODEL AND SUBJECT DETAILS
 
 Data on the ScPCA Portal was generated and compiled by each contributing lab and institution.
-As of May 1, 2026, gene expression data from 700 total samples is available. 
+As of May 1, 2026, gene expression data from 700 samples is available. 
 This includes 694 patient samples representing 55 different pediatric cancer types and 6 samples from human cell lines. 
 
 #### Metadata 
@@ -30,7 +30,7 @@ Table: Assignment of metadata fields to ontology terms. {#tbl:metadata}
 
 The majority (87%) of projects on the Portal have additional metadata fields, such as the presence or absence of treatment, tumor grade, or whether a sample was obtained from a primary tumor or metastasis.
 
-### Ethics statement
+#### Ethics statement
 
 For ALSF-funded datasets comprised of human subjects data, Institutional Review Boards (IRB) or research ethics boards at grantee institutions approved the research or determined it was exempt.
 For community-contributed datasets containing summarized data and de-identified metadata from human subjects, submitting institutions certified that all approvals and consents were obtained or listed the IRB protocol in transfer agreements.
@@ -39,7 +39,7 @@ ALSF-funded xenograft datasets were approved by the grantee institution's Instit
 
 ### METHOD DETAILS
 
-### Data generation and processing
+#### Data generation and processing
 
 Raw data and metadata were generated and compiled by each lab and institution contributing to the Portal.
 Single-cell or single-nuclei libraries were generated using one of the commercially available kits from 10x Genomics.
@@ -49,7 +49,7 @@ All libraries were processed using our open-source pipeline, `scpca-nf`, to prod
 A detailed summary with the total number of samples and libraries collected for each sequencing method broken down by project is available in Table S1.
 
 
-### Processing single-cell and single-nuclei RNA-seq data with alevin-fry
+#### Processing single-cell and single-nuclei RNA-seq data with alevin-fry
 
 To quantify RNA-seq gene expression for each cell or nucleus in a library, `scpca-nf` uses `salmon alevin` [@doi:10.1186/s13059-020-02151-8] and `alevin-fry` [@doi:10.1038/s41592-022-01408-3] to generate a gene-by-cell counts matrix.
 Prior to mapping, we generated an index using transcripts from both spliced cDNA and unspliced cDNA sequences, denoted as the `splici` index [@doi:10.1038/s41592-022-01408-3].
@@ -60,7 +60,7 @@ The RAD file was used as input to the recommended `alevin-fry` workflow, with th
 At the `generate-permit-list` step, we used the `--unfiltered-pl` option to provide a list of expected barcodes specific to the 10x kit used to generate each library.
 The `quant` step was run using the `cr-like-em` resolution strategy for feature quantification and UMI de-duplication.
 
-### Post alevin-fry processing of single-cell and single-nuclei RNA-seq data
+#### Post alevin-fry processing of single-cell and single-nuclei RNA-seq data
 
 The output from running `alevin-fry` includes a gene-by-cell counts matrix, with reads from both spliced and unspliced reads for all potential cell barcodes.
 The gene-by-cell counts matrix is read into R to create a `SingleCellExperiment` object using `fishpond::load_fry()`.
@@ -86,7 +86,7 @@ These were used as input to calculate the top 50 principal components using `sca
 Finally, UMAP embeddings were calculated from the principal components with `scater::runUMAP()`.
 The raw and log-normalized counts, list of 2000 high-variance genes, principal components, and UMAP embeddings are all stored in the processed objects saved as `.rds` files with the `_processed.rds` suffix.
 
-### Quantifying gene expression for libraries with CITE-seq or cell hashing
+#### Quantifying gene expression for libraries with CITE-seq or cell hashing
 
 All libraries with antibody-derived tags (ADTs) or hashtag oligonucleotides (HTOs) were mapped to a reference index using `salmon alevin` and quantified using `alevin-fry`.
 The reference indices were constructed using the `salmon index` command with the `--feature` option.
@@ -97,7 +97,7 @@ The `altExp` within the unfiltered object contains all identified ADTs or HTOs a
 Any barcodes that only appeared in either ADT or HTO data were discarded, and cell barcodes that were only found in the gene expression data (i.e., did not appear in the ADT or HTO data) were assigned zero counts for all ADTs and HTOs.
 Any cells removed after filtering empty droplets were also removed from the ADT and HTO counts matrices and before creating the filtered `SingleCellExperiment` object.
 
-### Processing ADT expression data from CITE-seq
+#### Processing ADT expression data from CITE-seq
 
 The ADT count matrix stored in the unfiltered object was used to calculate an ambient profile with `DropletUtils::ambientProfileEmpty()`.
 The ambient profile was used to calculate quality-control statistics with `DropletUtils::cleanTagCounts()` for all cells remaining after removing empty droplets.
@@ -115,7 +115,7 @@ Although `scpca-nf` normalizes ADT counts, the workflow does not perform any dim
 Additionally, note that we did not perform background subtraction on the ADT counts, but we provide the ambient profile calculated with `DropletUtils::ambientProfileEmpty()`, which users can employ to perform global de-noising as needed.
 During conversion to `AnnData` objects, the modalities are exported as separate RNA (`_rna.h5ad`) and ADT (`_adt.h5ad`) objects.
 
-### Processing HTO data from multiplexed libraries
+#### Processing HTO data from multiplexed libraries
 
 As with ADT data, `scpca-nf` does not filter any cells based on HTO expression, and any cells removed after filtering empty droplets based on the unfiltered RNA counts matrix are also removed from the HTO counts matrix in the filtered object.
 `scpca-nf` does not perform any additional filtering or processing of the HTO-by-cell counts matrix, so the same filtered matrix is included in the processed object.
@@ -124,7 +124,7 @@ To identify which cells come from which sample in a multiplexed library, we appl
 We do not provide separate `SingleCellExperiment` objects for each sample in a library.
 Each multiplexed library object contains the counts data from all samples and the results from all three demultiplexing methods to allow users to select which method(s) to use.
 
-#### Genetic demultiplexing
+##### Genetic demultiplexing
 
 If all samples in a multiplexed library were also sequenced using bulk RNA-seq, we performed genetic demultiplexing using genotype data from both bulk RNA-seq and single-cell or single-nuclei RNA-seq [@doi:10.1093/gigascience/giab062].
 If bulk RNA-seq was not available, no genetic demultiplexing was performed.
@@ -134,27 +134,27 @@ The mapped bulk reads were used to call variants and assign genotypes with `bcft
 `cellsnp-lite` was then used to genotype single-cell data at the identified sites found in the bulk RNA-seq data [@doi:10.1093/bioinformatics/btab358].
 Finally, `vireo` was used to identify the sample of origin [@doi:10.1093/bioinformatics/btab358].
 
-#### HTO demultiplexing
+##### HTO demultiplexing
 
 For all multiplexed libraries, we performed demultiplexing using `DropletUtils::hashedDrops()` and `Seurat::HTODemux()`.
 For both methods, we used the default parameters and only performed demultiplexing on the filtered cells present in the filtered object.
 The results from both these methods are available in the filtered and processed objects.
 
-### Quantification of spatial transcriptomics data
+#### Quantification of spatial transcriptomics data
 
 10x Genomics' Space Ranger [@url:https://www.10xgenomics.com/support/software/space-ranger/latest] was used to quantify gene expression data from spatial transcriptomics libraries.
 `cellranger mkref` was used to create a reference index from the human genome, GRCh38, Ensembl version 104.
 The FASTQ files, microscopic slide image, and slide serial number were provided as input to `spaceranger count`.
 The raw and filtered counts matrix, slide images, and the summary report output by `spaceranger count` are included in the output from `scpca-nf`.
 
-### Quantification of bulk RNA-seq data
+#### Quantification of bulk RNA-seq data
 
 `fastp` was used to trim adapters and perform quality and length filtering on all FASTQ files from bulk RNA-seq.
 We used a decoy-aware reference created from spliced cDNA sequences with the entire human genome sequence (GRCh38, Ensembl version 104) as the decoy [@doi:10.1038/nmeth.4197].
 The trimmed reads were then provided as input to `salmon quant` for selective alignment.
 In addition to using the default parameters for `salmon quant`, we applied the `--seqBias` and `--gcBias` flags to correct for sequence-specific biases due to random hexamer priming and fragment-level GC biases, respectively.
 
-### Cell type annotation
+#### Cell type annotation
 
 Cell type labels determined by `SingleR` [@doi:10.1038/s41590-018-0276-y], `CellAssign` [@doi:10.1038/s41592-019-0529-1], and `SCimilarity` [@doi:10.1038/s41586-024-08411-y] were added to processed `SingleCellExperiment` objects.
 If cell types were obtained from the submitter of the dataset, the submitter-provided annotations were incorporated into all `SingleCellExperiment` objects (unfiltered, filtered, and processed).
@@ -185,7 +185,7 @@ The assigned cell type label and the distance of the query cell to the closest c
 A plot showing the distribution of the distance metric calculated by `SCimilarity` is present in the cell type report. 
 Distances larger than 0.05 can indicate that the model is less confident in the prediction.
 
-#### Assigning consensus cell types
+##### Assigning consensus cell types
 
 Cell type labels obtained from `SingleR`, `CellAssign`, and `SCimilarity` were then used to assign an ontology-aware consensus cell type label.
 We first assigned each of the cell types present in the `PanglaoDB` [@doi:10.1093/database/baz046] reference used with `CellAssign` to an appropriate Cell Ontology term [@url:https://www.ebi.ac.uk/ols4/ontologies/cl].
@@ -209,7 +209,7 @@ Consensus cell type assignments were evaluated by looking at marker gene express
 Marker genes were obtained from the list of Human cell markers on `CellMarker 2.0` [@doi:10.1093/nar/gkac947].
 We considered only those that are specific to a single cell type, with the exception of hematopoietic precursor cells, which express genes found in other, more differentiated immune cells.
 
-#### Cell types annotated as part of the OpenScPCA Project
+##### Cell types annotated as part of the OpenScPCA Project
 
 As part of the ongoing OpenScPCA project [@url:https://openscpca.readthedocs.io], cell types for each project are manually annotated to label disease-specific cell types or cell states. 
 After annotations for all samples in a given project have been validated, they are added to all `SingleCellExperiment` objects (unfiltered, filtered, and processed) for that project on the Portal.
@@ -218,7 +218,7 @@ The approaches for cell type annotation were originally developed in the `OpenSc
 These analysis modules provide full information on the specific approaches used for annotation. 
 The cell type annotations included in the ScPCA Portal were subsequently generated in corresponding Nextflow modules in the `OpenScPCA-nf` GitHub repository [@url:https://github.com/AlexsLemonade/OpenScPCA-nf].
 
-### Copy-number variation inference
+#### Copy-number variation inference
 
 We used `inferCNV` [@url:https://github.com/broadinstitute/inferCNV] with the `i6` HMM to estimate copy-number variation (CNV) events for each library, for each chromosome arm.
 We designated a set of normal consensus cell types to use for each library's normal reference based on the given sample's diagnosis.
@@ -226,7 +226,7 @@ All libraries were processed with `inferCNV` except: i) libraries without assign
 We calculated the total CNVs per cell using the feature output from the `i6` HMM by summing CNV calls across all chromosome arms. 
 
 
-### Generating merged data
+#### Generating merged data
 
 Merged objects are created with the `merge.nf` workflow within `scpca-nf`.
 This workflow takes as input the processed `SingleCellExperiment` objects in a given ScPCA project output by `scpca-nf` and creates a single merged `SingleCellExperiment` object containing gene expression data and metadata from all libraries in that project.
@@ -245,7 +245,7 @@ If the merged object contains an `altExp` with merged ADT data, two `AnnData` ob
 If any libraries in the ScPCA project are multiplexed and contain HTO data, no merged object is created due to potential ambiguity in identifying samples across multiplexed libraries.
 Merged objects were not created for projects with more than 100 samples because of the computational resources required to work with them.
 
-### Converting SingleCellExperiment objects to AnnData objects
+#### Converting SingleCellExperiment objects to AnnData objects
 
 `zellkonverter::writeH5AD()` [@doi:10.18129/B9.bioc.zellkonverter] was used to convert `SingleCellExperiment` objects to `AnnData` format and export the objects as `.h5ad` files.
 For any `SingleCellExperiment` objects containing an `altExp` (e.g., ADT data), the RNA and ADT data were exported and saved separately as RNA (`_rna.h5ad`) and ADT (`_adt.h5ad`) files.
@@ -255,9 +255,9 @@ All merged `SingleCellExperiment` objects were converted to `AnnData` objects an
 If a merged `SingleCellExperiment` object contained any ADT data, the RNA and ADT data were exported and saved separately as RNA (`_rna.h5ad`) and ADT (`_adt.h5ad`) objects.
 In contrast, if a merged `SingleCellExperiment` object contained HTO data due to the presence of any multiplexed libraries in the merged object, the HTO data was removed from the `SingleCellExperiment` object and not included in the exported `AnnData` object.
 
-### Analysis of bulk RNA-seq data
+#### Analysis of bulk RNA-seq data
 
-#### Data preparation
+##### Data preparation
 
 We identified solid tumor samples with both bulk and single-cell (or single-nuclei) RNA-seq data in the ScPCA Portal for analysis, with multiplexed samples excluded (N=105).
 We removed low-quality samples based on visual inspection of quality control reports (N=8), leaving a total of 97 samples across five ScPCA projects for analysis.
@@ -267,7 +267,7 @@ We obtained pseudobulk counts by summing raw single-cell counts for each sample,
 We filtered out genes which were not observed in either the bulk or pseudobulk raw counts matrices before subsequent analysis.
 For each project, we then used the `lme4` R package [@doi:10.18637/jss.v067.i01] to construct a linear model predicting bulk from pseudobulk counts considering a random effect for sample id: `bulk ~ pseudobulk + (1|sample_id)`.
 
-#### Overrepresentation analysis
+##### Overrepresentation analysis
 
 We next conducted overrepresentation analysis (ORA) to ascertain whether certain cell types might be overrepresented either modality (bulk vs. pseudobulk).
 We specifically tested overrepresentation of the `PanglaoDB` cell type marker gene sets used for each project's respective `CellAssign` reference.

--- a/content/04.methods.md
+++ b/content/04.methods.md
@@ -5,8 +5,8 @@
 ### EXPERIMENTAL MODEL AND SUBJECT DETAILS
 
 Data on the ScPCA Portal were generated and compiled by each contributing lab and institution.
-As of May 1, 2026, gene expression data from 700 samples are available. 
-This includes 694 patient samples representing 55 different pediatric cancer types and 6 samples from human cell lines. 
+As of May 1, 2026, gene expression data from 704 samples are available. 
+This includes 585 human patient samples, 117 samples from patient-derived xenografts, 4 samples from immortalized human cell lines, and 2 samples from cell lines passaged from patient-derived xenografts representing 55 different pediatric cancer types.
 
 #### Metadata 
 


### PR DESCRIPTION
Closes #272 

Here I'm starting the process of modifying the methods section to match the STAR methods formatting guidelines. In this PR, I adjusted some of the headings and focused on the Experimentel model and subject details section. 

I decided to add a few sentences to discuss the total number of samples and disease types, including a break down of how many come from human patients vs cell lines. I think this covers the first and second bullet point asking about all the experimental models used in the study and sample size. 

I also moved the metadata and ethics sections that we had to be within this section. I think they make sense to include here but let me know if you disagree? 

While here, I also edited the headers for the remaining section, except the data availability section since I assume that will get moved into the resource availability section at the beginning as part of #269. 

Let me know if I missed any other details we should include here. 
