### PR TITLE
Quantification and statistical reporting section

### DIFF
--- a/build/assets/custom-dictionary.txt
+++ b/build/assets/custom-dictionary.txt
@@ -31,6 +31,7 @@ cbethell
 CCDL
 cDNA
 celldex
+cellranger
 CELLxGENE
 cgreene
 Chante

--- a/content/04.methods.md
+++ b/content/04.methods.md
@@ -305,6 +305,18 @@ All merged `SingleCellExperiment` objects were converted to `AnnData` objects an
 If a merged `SingleCellExperiment` object contained any ADT data, the RNA and ADT data were exported and saved separately as RNA (`_rna.h5ad`) and ADT (`_adt.h5ad`) objects.
 In contrast, if a merged `SingleCellExperiment` object contained HTO data due to the presence of any multiplexed libraries in the merged object, the HTO data was removed from the `SingleCellExperiment` object and not included in the exported `AnnData` object.
 
+### QUANTIFICATION AND STATISTICAL REPORTING
+
+Details regarding total sample and/or cell numbers and any statistical tests used can be found in the figure legends and figures. 
+For Figure {@fig:fig4}, Figure {@fig:fig5}, Figure {@fig:figS4}, and Figure {@fig:figS5}, numbers in parentheses in the figure indicate total cell numbers.
+For Figure {@fig:fig1}, Figure {@fig:fig6}, and Figure {@fig:figS7}, numbers in parenthesis in the figure indicate total sample numbers.
+
+#### Benchmarking of `alevin-fry` and `CellRanger` performance 
+
+Six libraries, three single-cell and three single-nuclei, were randomly selected and used to benchmark the performance of `alevin-fry` and `CellRanger`, results of which are shown in Supplemental Figure 1. 
+Libraries were processed with `salmon alevin v1.5.2` and `alevin-fry v0.4.1` or `cellranger count` from `CellRanger v6.1.2`.
+Results were generated using default parameters for single-cell libraries and use of the `--include_introns` flag to include intronic reads for single-nuclei libraries only. The Pearson correlation between mean gene expression across both methods is reported in Supplemental Figure 1B.
+
 #### Analysis of bulk RNA-seq data
 
 ##### Data preparation

--- a/content/04.methods.md
+++ b/content/04.methods.md
@@ -311,10 +311,10 @@ Details regarding total sample and/or cell numbers and any statistical tests use
 For Figure {@fig:fig4}, Figure {@fig:fig5}, Figure {@fig:figS4}, and Figure {@fig:figS5}, numbers in parentheses in the figure indicate total cell numbers.
 For Figure {@fig:fig1}, Figure {@fig:fig6}, and Figure {@fig:figS7}, numbers in parenthesis in the figure indicate total sample numbers.
 
-#### Benchmarking of `alevin-fry` and `CellRanger` performance 
+#### Benchmarking of `alevin-fry` and `cellranger count` performance 
 
 Six libraries, three single-cell and three single-nuclei, were randomly selected and used to benchmark the performance of `alevin-fry` and `cellranger count`, results of which are shown in Figure {@fig:figS1}. 
-Libraries were processed with `salmon alevin` v1.5.2 and `alevin-fry` v0.4.1 or `cellranger count` from CellRanger v6.1.2.
+Libraries were processed with `salmon alevin` v1.5.2 and `alevin-fry` v0.4.1 or `cellranger count` from Cell Ranger v6.1.2.
 Results were generated using default parameters for single-cell libraries and use of the `--include_introns` flag to include intronic reads for single-nuclei libraries only. 
 The Pearson correlation between mean gene expression across both methods is reported in Figure {@fig:figS1}B.
 

--- a/content/04.methods.md
+++ b/content/04.methods.md
@@ -313,9 +313,10 @@ For Figure {@fig:fig1}, Figure {@fig:fig6}, and Figure {@fig:figS7}, numbers in 
 
 #### Benchmarking of `alevin-fry` and `CellRanger` performance 
 
-Six libraries, three single-cell and three single-nuclei, were randomly selected and used to benchmark the performance of `alevin-fry` and `CellRanger`, results of which are shown in Supplemental Figure 1. 
-Libraries were processed with `salmon alevin v1.5.2` and `alevin-fry v0.4.1` or `cellranger count` from `CellRanger v6.1.2`.
-Results were generated using default parameters for single-cell libraries and use of the `--include_introns` flag to include intronic reads for single-nuclei libraries only. The Pearson correlation between mean gene expression across both methods is reported in Supplemental Figure 1B.
+Six libraries, three single-cell and three single-nuclei, were randomly selected and used to benchmark the performance of `alevin-fry` and `cellranger count`, results of which are shown in Figure {@fig:figS1}. 
+Libraries were processed with `salmon alevin` v1.5.2 and `alevin-fry` v0.4.1 or `cellranger count` from CellRanger v6.1.2.
+Results were generated using default parameters for single-cell libraries and use of the `--include_introns` flag to include intronic reads for single-nuclei libraries only. 
+The Pearson correlation between mean gene expression across both methods is reported in Figure {@fig:figS1}B.
 
 #### Analysis of bulk RNA-seq data
 

--- a/content/100.figure-table-legends.md
+++ b/content/100.figure-table-legends.md
@@ -168,15 +168,15 @@ Marker genes for all cell types in each organ were included.
 <!-- Figure S1 -->
 ![**Results from benchmarking `alevin-fry` and `cellranger count` performance.**](https://raw.githubusercontent.com/AlexsLemonade/scpca-paper-figures/v0.2.2/figures/compiled_figures/pngs/figure_s1.png?sanitize=true){#fig:figS1 tag="S1" width="7in"}
 
-Panels compare metrics for six ScPCA libraries (three single-cell and three single-nuclei), obtained from processing with `salmon alevin` and `alevin-fry` or `CellRanger`.
-Results were generated with `CellRanger v6.1.2` using default parameters for single-cell libraries and the `--include_introns` flag to include intronic reads for single-nuclei libraries only.
-Libraries were processed with `salmon alevin v1.5.2` and `alevin-fry v0.4.1` using an index containing both spliced and unspliced cDNA (see Methods).
+Panels compare metrics for six ScPCA libraries (three single-cell and three single-nuclei), obtained from processing with `salmon alevin` and `alevin-fry` or `cellranger count`.
+Results were generated with CellRanger v6.1.2 using default parameters for single-cell libraries and the `--include_introns` flag to include intronic reads for single-nuclei libraries only.
+Libraries were processed with `salmon alevin` v1.5.2 and `alevin-fry` v0.4.1 using an index containing both spliced and unspliced cDNA (see Methods).
 Libraries used for benchmarking were randomly chosen.
 
 A. Runtime in minutes (top row) and peak memory in GB (bottom row) for libraries processed with both platforms.
-Processing with `alevin-fry` was consistently faster and more memory-efficient than processing with `CellRanger`.
+Processing with `alevin-fry` was consistently faster and more memory-efficient than processing with `cellranger count`.
 
-Panels B-D show only cells present in both `alevin-fry` and `CellRanger` outputs.
+Panels B-D show only cells present in both `alevin-fry` and `cellranger count` outputs.
 
 B. Comparison of mean gene expression values for libraries processed with both platforms, shown on a log-scale.
 Each point is a gene, and only genes detected in at least 5 cells are shown.

--- a/content/100.figure-table-legends.md
+++ b/content/100.figure-table-legends.md
@@ -186,27 +186,27 @@ The reference includes marker genes for all cell types present in each organ.
 <br><br>
 
 <!-- Figure S1 -->
-![**Results from benchmarking `alevin-fry` and `CellRanger` performance.**](https://raw.githubusercontent.com/AlexsLemonade/scpca-paper-figures/v0.2.2/figures/compiled_figures/pngs/figure_s1.png?sanitize=true){#fig:figS1 tag="S1" width="7in"}
+![**Results from benchmarking `alevin-fry` and `cellranger count` performance.**](https://raw.githubusercontent.com/AlexsLemonade/scpca-paper-figures/v0.2.2/figures/compiled_figures/pngs/figure_s1.png?sanitize=true){#fig:figS1 tag="S1" width="7in"}
 
-Each panel compares metrics for six ScPCA libraries, including three single-cell and three single-nuclei suspensions, obtained from processing libraries with `salmon alevin` and `alevin-fry` or `CellRanger`.
-Results shown were generated with `CellRanger v6.1.2` using default parameters for single-cell libraries and use of the `--include_introns` flag to include intronic reads for single-nuclei libraries only.
-All libraries were processed with `salmon alevin v1.5.2` and `alevin-fry v0.4.1` using an index containing both spliced and unspliced cDNA as mentioned in the Methods.
+Each panel compares metrics for six ScPCA libraries, including three single-cell and three single-nuclei suspensions, obtained from processing libraries with `salmon alevin` and `alevin-fry` or `cellranger count`.
+Results shown were generated with Cell Ranger v6.1.2 using default parameters for single-cell libraries and use of the `--include_introns` flag to include intronic reads for single-nuclei libraries only.
+All libraries were processed with `salmon alevin` v1.5.2 and `alevin-fry` v0.4.1 using an index containing both spliced and unspliced cDNA as mentioned in the Methods.
 The libraries used for benchmarking were randomly chosen.
 
 
-A. Runtime in minutes (top row) and peak memory in GB (bottom row) for six ScPCA libraries processed with `alevin-fry` and `CellRanger`.
-Processing with `alevin-fry` was consistently faster and more memory-efficient compared to processing with `CellRanger`.
+A. Runtime in minutes (top row) and peak memory in GB (bottom row) for six ScPCA libraries processed with `alevin-fry` and `cellranger count`.
+Processing with `alevin-fry` was consistently faster and more memory-efficient compared to processing with `cellranger count`.
 
-Panels B-D show only cells present in both the `alevin-fry` and `CellRanger` output.
+Panels B-D show only cells present in both the `alevin-fry` and `cellranger count` output.
 
-B. Comparison of mean gene expression values for six ScPCA libraries processed with `alevin-fry` and `CellRanger`, shown on a log-scale.
+B. Comparison of mean gene expression values for six ScPCA libraries processed with `alevin-fry` and `cellranger count`, shown on a log-scale.
 Each point is a gene, and only genes detected in at least 5 cells are shown.
 $R^2$ values shown in the top left corner of each panel reflect broad agreement in mean gene expression values between platforms.
 
-C. Comparison of log total UMI counts for six ScPCA libraries processed with `alevin-fry` and `CellRanger`.
+C. Comparison of log total UMI counts for six ScPCA libraries processed with `alevin-fry` and `cellranger count`.
 Distributions reflect broad agreement in the total UMI count per cell between platforms, although `alevin-fry` returned slightly higher values for certain single-cell libraries.
 
-D. Comparison of log total genes detected per cell for six ScPCA libraries processed with `alevin-fry` and `CellRanger`.
+D. Comparison of log total genes detected per cell for six ScPCA libraries processed with `alevin-fry` and `cellranger count`.
 Distributions reflect broad agreement between platforms in the total number of genes detected per cell between platforms, although `alevin-fry` returned slightly higher values for certain single-cell libraries.
 <br><br>
 


### PR DESCRIPTION
Closes #274 
~~Stacked on #284~~

This PR adds in the quantification and statistical reporting section. I was a little at a loss here because we don't really do a whole lot of quantitative analysis... I ended up including a few sentences describing what the numbers in each of the figures are (total samples vs. total cells) since that's what's specifically asked for in the description of this section. 

I also added a new section describing the benchmarking and that we used Pearson correlation to look at the correlation of mean gene expression across methods. And then I moved the bulk RNA analysis to this section since I think it fits more with the quantification and statistical analysis than "method details", but let me know if you disagree. 

Finally, while here I fixed some issues with how we were referring to Cell Ranger and `cellranger count` in the figure legends. In the results section we use Cell Ranger (without backticks) and we should do the same in the figure legends. If we are specifically talking about `cellranger count` then that should be formatted in that way. I think this might cause some small conflicts with #285 that we'll have to resolve depending on which is merged first. 